### PR TITLE
VSTS-135 - Task fails to install on TFS earlier than 2017 Update 2

### DIFF
--- a/extensions/sonarqube/overview.md
+++ b/extensions/sonarqube/overview.md
@@ -4,13 +4,16 @@ SonarQube can be [installed][getstarted] and run on a dedicated infrastructure.
 
 The analysis of the source code doesn't happen on the server side, but must be part of the build chain to make the analysis as accurate as possible. These analyses are performed using scanners.
 
-## About the SonarQube VSTS Marketplace Extension
+## About the SonarQube VSTS/TFS Marketplace Extension
 This extension provides the following features:
 * A dedicated **SonarQube EndPoint** to define the SonarQube server to be used.
 * Three build tasks to get your projects analyzed easily:
   * **Prepare Analysis Configuration** task, to configure all the required settings before executing the build. This task is mandatory. In case of .NET solutions or Java projects, this tasks helps to integrate seamlessly with MSBuild, Maven and Gradle tasks.
   * **Run Code Analysis** task, to actually execute the analysis of the source code. Not required for Maven or Gradle projects.
   * **Publish Analysis Result** task, to display the quality gate status in the build summary. This tasks is optional, as it can increase the overall build time.
+
+**Note for TFS installations older than TFS 2017 Update 2**: to install the extension, please follow instructions
+available on the ["SonarQube Extension 3.0" documentation page](https://docs.sonarqube.org/display/SCAN/SonarQube+Extension+3.0).
 
 ## Highlighted Features
 ### Seamless Integration with .Net solutions


### PR DESCRIPTION
@henryju I've added a notice for users on old TFS versions.

I also updated the doc on https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Extension+for+VSTS-TFS:
* to specify the compatibility for each version
* to tell how to install older versions of the extension and redirect to the correct doc page

If I'm not mistaken, the only thing that remains on your side is:
* to update the manifest in order to set the right compatibility for the upcoming 4.0.2 release
* to read and validate the changes I made (in this PR and on the doc)