### PR TITLE
Enable Pull Request analysis with Github

### DIFF
--- a/common/powershell/SonarQubeHelper.ps1
+++ b/common/powershell/SonarQubeHelper.ps1
@@ -230,13 +230,20 @@ function IsPrBuild
 {    
     $sourceBranch = $env:Build_SourceBranch
     $scProvider = $env:Build_Repository_Provider
+    $buildReason = $env:BUILD_REASON
 
     return   $scProvider -and `
              ($scProvider -eq "TfsGit") -and `
              $sourceBranch -and `
-             $sourceBranch.StartsWith("refs/pull/", [StringComparison]::OrdinalIgnoreCase)        
+             $sourceBranch.StartsWith("refs/pull/", [StringComparison]::OrdinalIgnoreCase) -or `
+             ($buildReason -eq "PullRequest")
 }
 
+function IsTfsBuild
+{
+    $scProvider = $env:Build_Repository_Provider
+    return $scProvider -and ($scProvider -eq "TfsGit")
+}
 
 function GetSonarQubeBuildDirectory
 {

--- a/extensions/sonarqube/tasks/analyze/old/PRCA/Orchestrator.ps1
+++ b/extensions/sonarqube/tasks/analyze/old/PRCA/Orchestrator.ps1
@@ -3,8 +3,10 @@
 #
 function HandleCodeAnalysisReporting
 {	
-    
-    if (IsPrBuild)
+    $tfsBuild = IsTfsBuild
+    $prBuild = IsPrBuild
+
+    if ($prBuild -and $tfsBuild)
     {   
         Write-Host "Fetching code analysis issues and posting them to the PR..."
            


### PR DESCRIPTION
We are building with VSTS and were using the scanner to analyse our pull requests. This worked great when our source was in VSTS. We moved our code to Github and we still want to have comments on our pull requests.

We are using the Github Plugin in SonarQube and comments are created. But the analysis failed, because this extension is thinking that it is not a PR, although mode was forced to 'issues'.

This change uses the predefined build variable to check if it's a pull request: https://docs.microsoft.com/en-us/vsts/build-release/concepts/definitions/build/variables?tabs=batch#predefined-variables

The other change is to check if it's a TfsBuild. If it's not, don't bother to kick off post comments module.

I am not sure if you want to support Github with VSTS like this, but it works for me. Btw, we are still using v3.