### PR TITLE
Allow Multiple Scans To Be Published

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 build
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ install:
   - npm install
   - npm run install-dep
 before_script: npm run clean && npm run validate
-script:  npm run deploy && git fetch --unshallow && npm run sonarqube
+script:  
+  - if [ -n "$ARTIFACTORY_URL" ]; then npm run deploy; fi
+  - git fetch --unshallow && npm run sonarqube
 
 notifications:
   email: false

--- a/common/ts/sonarqube/Analysis.ts
+++ b/common/ts/sonarqube/Analysis.ts
@@ -23,6 +23,7 @@ export default class Analysis {
   constructor(
     private analysis: IAnalysis,
     private endpointType: EndpointType,
+    private projectName: string,
     private metrics?: Metrics,
     private dashboardUrl?: string
   ) {}
@@ -41,10 +42,10 @@ export default class Analysis {
     );
   }
 
-  public getHtmlAnalysisReport() {
+  public getHtmlAnalysisReport(includeProjectName = false) {
     tl.debug(`[SQ] Generate analysis report.'`);
     return [
-      this.getQualityGateSection(),
+      this.getQualityGateSection(includeProjectName),
       this.getQualityGateDetailSection(),
       this.getDashboardLink()
     ]
@@ -52,7 +53,7 @@ export default class Analysis {
       .trim();
   }
 
-  private getQualityGateSection() {
+  private getQualityGateSection(includeProjectName = false) {
     const qgStyle = `background-color: ${this.getQualityGateColor()};
       padding: 4px 12px;
       color: #fff;
@@ -62,7 +63,7 @@ export default class Analysis {
       font-size: 12px;
       margin-left: 15px;`;
     return `<div style="padding-top: 8px;">
-      <span>Quality Gate</span>
+      <span>${includeProjectName ? this.projectName + ' ' : ''}Quality Gate</span>
       <span style="${qgStyle}">
         ${formatMeasure(this.status, 'LEVEL')}
       </span>
@@ -131,6 +132,7 @@ export default class Analysis {
 
   public static getAnalysis(
     analysisId: string,
+    projectName: string,
     endpoint: Endpoint,
     metrics?: Metrics,
     dashboardUrl?: string
@@ -138,7 +140,7 @@ export default class Analysis {
     tl.debug(`[SQ] Retrieve Analysis id '${analysisId}.'`);
     return getJSON(endpoint, '/api/qualitygates/project_status', { analysisId }).then(
       ({ projectStatus }: { projectStatus: IAnalysis }) =>
-        new Analysis(projectStatus, endpoint.type, metrics, dashboardUrl),
+        new Analysis(projectStatus, endpoint.type, projectName, metrics, dashboardUrl),
       err => {
         if (err && err.message) {
           tl.error(`[SQ] Error retrieving analysis: ${err.message}`);

--- a/common/ts/sonarqube/Scanner.ts
+++ b/common/ts/sonarqube/Scanner.ts
@@ -82,7 +82,7 @@ export class ScannerCLI extends Scanner {
 
   public async runAnalysis() {
     let scannerCliScript = tl.resolve(this.rootPath, 'sonar-scanner', 'bin', 'sonar-scanner');
-    
+
     if (isWindows()) {
       scannerCliScript += '.bat';
     } else {
@@ -127,14 +127,14 @@ export class ScannerMSBuild extends Scanner {
 
   public async runPrepare() {
     let scannerRunner;
-    
+
     if (isWindows()) {
       const scannerExePath = this.findFrameworkScannerPath();
       tl.debug(`Using classic scanner at ${scannerExePath}`);
       tl.setVariable('SONARQUBE_SCANNER_MSBUILD_EXE', scannerExePath);
       scannerRunner = this.getScannerRunner(scannerExePath, true);
     } else {
-      const scannerDllPath = this.findDotnetScannerPath()
+      const scannerDllPath = this.findDotnetScannerPath();
       tl.debug(`Using dotnet scanner at ${scannerDllPath}`);
       tl.setVariable('SONARQUBE_SCANNER_MSBUILD_DLL', scannerDllPath);
       scannerRunner = this.getScannerRunner(scannerDllPath, false);
@@ -147,7 +147,7 @@ export class ScannerMSBuild extends Scanner {
     await scannerRunner.exec();
   }
 
-  private async makeShellScriptExecutable(scannerExecutablePath : string) {
+  private async makeShellScriptExecutable(scannerExecutablePath: string) {
     const scannerCliShellScripts = tl.findMatch(
       scannerExecutablePath,
       path.join(path.dirname(scannerExecutablePath), 'sonar-scanner-*', 'bin', 'sonar-scanner')
@@ -155,7 +155,7 @@ export class ScannerMSBuild extends Scanner {
     await fs.chmod(scannerCliShellScripts, '777');
   }
 
-  private getScannerRunner(scannerPath : string, isExeScanner : boolean) {
+  private getScannerRunner(scannerPath: string, isExeScanner: boolean) {
     if (isExeScanner) {
       return tl.tool(scannerPath);
     }
@@ -166,20 +166,12 @@ export class ScannerMSBuild extends Scanner {
     return scannerRunner;
   }
 
-  private findFrameworkScannerPath() : string {
-    return tl.resolve(
-      this.rootPath,
-      'classic-sonar-scanner-msbuild',
-      'SonarScanner.MSBuild.exe'
-    );
+  private findFrameworkScannerPath(): string {
+    return tl.resolve(this.rootPath, 'classic-sonar-scanner-msbuild', 'SonarScanner.MSBuild.exe');
   }
 
-  private findDotnetScannerPath() : string  {
-    return tl.resolve(
-      this.rootPath,
-      'dotnet-sonar-scanner-msbuild',
-      'SonarScanner.MSBuild.dll'
-    );
+  private findDotnetScannerPath(): string {
+    return tl.resolve(this.rootPath, 'dotnet-sonar-scanner-msbuild', 'SonarScanner.MSBuild.dll');
   }
 
   public async runAnalysis() {

--- a/common/ts/sonarqube/Task.ts
+++ b/common/ts/sonarqube/Task.ts
@@ -8,6 +8,7 @@ interface ITask {
   organization?: string;
   status: string;
   type: string;
+  componentName: string;
 }
 
 export default class Task {
@@ -15,6 +16,10 @@ export default class Task {
 
   public get analysisId() {
     return this.task.analysisId;
+  }
+
+  public get componentName() {
+    return this.task.componentName;
   }
 
   public static waitForTaskCompletion(

--- a/common/ts/sonarqube/__tests__/Analysis-test.ts
+++ b/common/ts/sonarqube/__tests__/Analysis-test.ts
@@ -37,6 +37,7 @@ beforeEach(() => {
 it('should generate an analysis status with error', async () => {
   const analysis = await Analysis.getAnalysis(
     'analysisId',
+    'projectName',
     ENDPOINT,
     METRICS,
     'https://dashboard.url'
@@ -56,6 +57,7 @@ it('should generate a green analysis status', async () => {
 
   const analysis = await Analysis.getAnalysis(
     'analysisId',
+    'projectName',
     ENDPOINT,
     METRICS,
     'https://dashboard.url'
@@ -69,7 +71,7 @@ it('should generate a green analysis status', async () => {
 });
 
 it('should not fail when metrics are missing', async () => {
-  const analysis = await Analysis.getAnalysis('analysisId', ENDPOINT);
+  const analysis = await Analysis.getAnalysis('analysisId', 'projectName', ENDPOINT);
   expect(getJSON).toHaveBeenCalledWith(ENDPOINT, '/api/qualitygates/project_status', {
     analysisId: 'analysisId'
   });

--- a/config/paths.js
+++ b/config/paths.js
@@ -29,7 +29,7 @@ exports.paths = {
       sonarcloudTasks: path.join(buildPath, 'extensions', 'sonarcloud', 'tasks')
     },
     classicScanner: path.join(buildPath, 'tmp', 'classic-sonar-scanner-msbuild'),
-    dotnetScanner:  path.join(buildPath, 'tmp', 'dotnet-sonar-scanner-msbuild')
+    dotnetScanner: path.join(buildPath, 'tmp', 'dotnet-sonar-scanner-msbuild')
   },
   common: {
     old: path.join(commonPath, 'powershell'),

--- a/config/utils.js
+++ b/config/utils.js
@@ -149,8 +149,8 @@ exports.runSonnarQubeScanner = function(callback, options = {}) {
   };
   sonarqubeScanner(
     {
-      serverUrl: process.env.SONAR_HOST_URL,
-      token: process.env.SONAR_TOKEN,
+      serverUrl: process.env.SONAR_HOST_URL || process.env.SONAR_HOST_URL_EXTERNAL_PR,
+      token: process.env.SONAR_TOKEN || process.env.SONAR_TOKEN_EXTERNAL_PR,
       options: {
         ...commonOptions,
         ...options

--- a/config/utils.js
+++ b/config/utils.js
@@ -136,7 +136,8 @@ exports.runSonnarQubeScanner = function(callback, options = {}) {
   const commonOptions = {
     'sonar.projectKey': 'org.sonarsource.scanner.vsts:sonar-scanner-vsts',
     'sonar.projectName': 'SonarQube Scanner for TFS/VSTS',
-    'sonar.exclusions': 'build/**, coverage/**, node_modules/**, **/node_modules/**, **/__tests__/**',
+    'sonar.exclusions':
+      'build/**, coverage/**, node_modules/**, **/node_modules/**, **/__tests__/**',
     'sonar.coverage.exclusions':
       'gulpfile.js, build/**, config/**, coverage/**, scripts/**, **/__tests__/**',
     'sonar.tests': '.',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,34 +40,53 @@ gulp.task('npminstall', () =>
 );
 
 gulp.task('scanner:download', () => {
-    const classicDownload = download(scanner.classicUrl)
-      .pipe(decompress())
-      .pipe(gulp.dest(paths.build.classicScanner));
+  const classicDownload = download(scanner.classicUrl)
+    .pipe(decompress())
+    .pipe(gulp.dest(paths.build.classicScanner));
 
-    const dotnetDownload = download(scanner.dotnetUrl)
-      .pipe(decompress())
-      .pipe(gulp.dest(paths.build.dotnetScanner));
+  const dotnetDownload = download(scanner.dotnetUrl)
+    .pipe(decompress())
+    .pipe(gulp.dest(paths.build.dotnetScanner));
 
-    return es.merge(classicDownload, dotnetDownload);
-  }
-);
+  return es.merge(classicDownload, dotnetDownload);
+});
 
 gulp.task('scanner:copy', ['scanner:download'], () => {
   const scannerFolders = [
-    path.join(paths.build.extensions.sonarqubeTasks,  'prepare', 'old', 'SonarQubeScannerMsBuild'),
-    path.join(paths.build.extensions.sonarqubeTasks,  'prepare', 'new', 'classic-sonar-scanner-msbuild'),
-    path.join(paths.build.extensions.sonarcloudTasks, 'prepare', 'new', 'classic-sonar-scanner-msbuild')
+    path.join(paths.build.extensions.sonarqubeTasks, 'prepare', 'old', 'SonarQubeScannerMsBuild'),
+    path.join(
+      paths.build.extensions.sonarqubeTasks,
+      'prepare',
+      'new',
+      'classic-sonar-scanner-msbuild'
+    ),
+    path.join(
+      paths.build.extensions.sonarcloudTasks,
+      'prepare',
+      'new',
+      'classic-sonar-scanner-msbuild'
+    )
   ];
 
   const dotnetScannerFolders = [
-    path.join(paths.build.extensions.sonarqubeTasks,  'prepare', 'new', 'dotnet-sonar-scanner-msbuild'),
-    path.join(paths.build.extensions.sonarcloudTasks, 'prepare', 'new', 'dotnet-sonar-scanner-msbuild')
+    path.join(
+      paths.build.extensions.sonarqubeTasks,
+      'prepare',
+      'new',
+      'dotnet-sonar-scanner-msbuild'
+    ),
+    path.join(
+      paths.build.extensions.sonarcloudTasks,
+      'prepare',
+      'new',
+      'dotnet-sonar-scanner-msbuild'
+    )
   ];
 
   const cliFolders = [
-    path.join(paths.build.extensions.sonarqubeTasks,  'scanner-cli', 'old', 'sonar-scanner'),
-    path.join(paths.build.extensions.sonarqubeTasks,  'analyze',     'new', 'sonar-scanner'),
-    path.join(paths.build.extensions.sonarcloudTasks, 'analyze',     'new', 'sonar-scanner')
+    path.join(paths.build.extensions.sonarqubeTasks, 'scanner-cli', 'old', 'sonar-scanner'),
+    path.join(paths.build.extensions.sonarqubeTasks, 'analyze', 'new', 'sonar-scanner'),
+    path.join(paths.build.extensions.sonarcloudTasks, 'analyze', 'new', 'sonar-scanner')
   ];
   let scannerPipe = gulp.src(pathAllFiles(paths.build.classicScanner));
   scannerFolders.forEach(dir => {
@@ -79,7 +98,9 @@ gulp.task('scanner:copy', ['scanner:download'], () => {
     dotnetScannerPipe = dotnetScannerPipe.pipe(gulp.dest(dir));
   });
 
-  let cliPipe = gulp.src(pathAllFiles(paths.build.classicScanner, `sonar-scanner-${scanner.cliVersion}`));
+  let cliPipe = gulp.src(
+    pathAllFiles(paths.build.classicScanner, `sonar-scanner-${scanner.cliVersion}`)
+  );
   cliFolders.forEach(dir => {
     cliPipe = cliPipe.pipe(gulp.dest(dir));
   });


### PR DESCRIPTION
This will allow multiple scans to be published to the build summary. A use case would be an Angular project with .NET backend where one scan would come from MSBUILD and the other from the sonar-scanner on the TypeScript front end.

I also added placing the project name next to the quality gate to differentiate which report belongs to which gate.

![image](https://user-images.githubusercontent.com/28767221/38763906-1c3809c2-3f6b-11e8-8668-070031a8f1bb.png)
