### PR TITLE
Update task versions for release of SC 1.2.0 and SQ 4.2.0

### DIFF
--- a/extensions/sonarcloud/tasks/analyze/new/task.json
+++ b/extensions/sonarcloud/tasks/analyze/new/task.json
@@ -10,8 +10,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.119.1",
   "demands": ["java"],

--- a/extensions/sonarcloud/tasks/prepare/new/task.json
+++ b/extensions/sonarcloud/tasks/prepare/new/task.json
@@ -10,8 +10,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.95.1",
   "instanceNameFormat": "Prepare analysis on SonarCloud",

--- a/extensions/sonarcloud/tasks/publish/new/task.json
+++ b/extensions/sonarcloud/tasks/publish/new/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.1",

--- a/extensions/sonarqube/tasks/analyze/new/task.json
+++ b/extensions/sonarqube/tasks/analyze/new/task.json
@@ -10,8 +10,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.119.1",

--- a/extensions/sonarqube/tasks/analyze/old/task.json
+++ b/extensions/sonarqube/tasks/analyze/old/task.json
@@ -10,8 +10,8 @@
   "author": "SonarSource",
   "version": {
     "Major": 3,
-    "Minor": 2,
-    "Patch": 1
+    "Minor": 3,
+    "Patch": 0
   },
   "demands": ["msbuild", "java"],
   "minimumAgentVersion": "1.95.0",

--- a/extensions/sonarqube/tasks/prepare/new/task.json
+++ b/extensions/sonarqube/tasks/prepare/new/task.json
@@ -10,8 +10,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 1,
-    "Patch": 1
+    "Minor": 2,
+    "Patch": 0
   },
   "releaseNotes":
     "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",

--- a/extensions/sonarqube/tasks/prepare/old/task.json
+++ b/extensions/sonarqube/tasks/prepare/old/task.json
@@ -10,8 +10,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 2,
-    "Patch": 1
+    "Minor": 3,
+    "Patch": 0
   },
   "demands": ["msbuild", "java"],
   "minimumAgentVersion": "1.95.0",

--- a/extensions/sonarqube/tasks/publish/new/task.json
+++ b/extensions/sonarqube/tasks/publish/new/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.1",


### PR DESCRIPTION
I've incremented the minor versions of all of tasks, except for the "old cli" task which has not changed because the version of the embedded CLI has not changed.

It wasn't strictly necessary to update the versions of the "publish" tasks, but it's less confusing to have the "new" tasks at the same version number.
