### PR TITLE
Embed Scanner for MSBuild 4.4.2.1543

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,4 @@
-const msBuildVersion = '4.4.1.1530';
+const msBuildVersion = '4.4.2.1543';
 const cliVersion = '3.2.0.1227'; // Has to be the same version as the one embedded in the Scanner for MSBuild
 
 const scannerUrlCommon =

--- a/extensions/sonarcloud/tasks/analyze/new/task.json
+++ b/extensions/sonarcloud/tasks/analyze/new/task.json
@@ -10,7 +10,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 4,
+    "Minor": 5,
     "Patch": 0
   },
   "minimumAgentVersion": "2.119.1",

--- a/extensions/sonarcloud/tasks/prepare/new/task.json
+++ b/extensions/sonarcloud/tasks/prepare/new/task.json
@@ -10,7 +10,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 4,
+    "Minor": 5,
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.1",

--- a/extensions/sonarqube/tasks/analyze/new/task.json
+++ b/extensions/sonarqube/tasks/analyze/new/task.json
@@ -10,7 +10,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 4,
+    "Minor": 5,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",

--- a/extensions/sonarqube/tasks/analyze/old/task.json
+++ b/extensions/sonarqube/tasks/analyze/old/task.json
@@ -10,7 +10,7 @@
   "author": "SonarSource",
   "version": {
     "Major": 3,
-    "Minor": 5,
+    "Minor": 6,
     "Patch": 0
   },
   "demands": ["msbuild", "java"],

--- a/extensions/sonarqube/tasks/prepare/new/task.json
+++ b/extensions/sonarqube/tasks/prepare/new/task.json
@@ -10,7 +10,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 4,
+    "Minor": 5,
     "Patch": 0
   },
   "releaseNotes":

--- a/extensions/sonarqube/tasks/prepare/old/task.json
+++ b/extensions/sonarqube/tasks/prepare/old/task.json
@@ -10,7 +10,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 3,
-    "Minor": 5,
+    "Minor": 6,
     "Patch": 0
   },
   "demands": ["msbuild", "java"],


### PR DESCRIPTION
Hotfix for https://github.com/SonarSource/sonar-scanner-msbuild/issues/589 which is causing issues for pretty much every project that has an `.sfproj` or `.deployproj` file in their solution(s).

Related SonarSource community thread: https://community.sonarsource.com/t/azure-devops-build-fail-with-deployproj-with-missing-parameter-language-error/3314