### PR TITLE
Update request.ts for SELF_SIGNED_CERT_IN_CHAIN node error

### DIFF
--- a/common/ts/helpers/request.ts
+++ b/common/ts/helpers/request.ts
@@ -16,6 +16,7 @@ function get(endpoint: Endpoint, path: string, isJson: boolean, query?: RequestD
     if (query) {
       options.qs = query;
       options.useQuerystring = true;
+      options.rejectUnauthorized = false;
     }
     request.get(
       {


### PR DESCRIPTION
set rejectUnauthorized: false so that the Azure DevOps scanner can communicate with an instance of SonarQube that uses self-signed certificates. This avoids the node error SELF_SIGNED_CERT_IN_CHAIN