### PR TITLE
Provide error message when SQ task failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ build/
 # VS Code
 .vscode/
 
+# IntelliJ IDEA
+.idea/
+
 # nodeJS dependencies
 node_modules/
 

--- a/common/ts/sonarqube/Task.ts
+++ b/common/ts/sonarqube/Task.ts
@@ -7,6 +7,7 @@ interface ITask {
   componentKey: string;
   organization?: string;
   status: string;
+  errorMessage?: string;
   type: string;
   componentName: string;
 }
@@ -35,10 +36,11 @@ export default class Task {
         if (tries <= 0) {
           throw new TimeOutReachedError();
         }
+        const errorMessage = task.errorMessage ? task.errorMessage : 'Not provided by Sonar Server';
         switch (task.status.toUpperCase()) {
           case 'CANCEL':
           case 'FAILED':
-            throw new Error(`[SQ] Task failed with status ${task.status}`);
+            throw new Error(`[SQ] Task failed with status ${task.status}, Error message: ${errorMessage}`);
           case 'SUCCESS':
             tl.debug(`[SQ] Task complete: ${JSON.stringify(task)}`);
             return new Task(task);

--- a/common/ts/sonarqube/Task.ts
+++ b/common/ts/sonarqube/Task.ts
@@ -36,11 +36,11 @@ export default class Task {
         if (tries <= 0) {
           throw new TimeOutReachedError();
         }
-        const errorMessage = task.errorMessage ? task.errorMessage : 'Not provided by Sonar Server';
+        const errorInfo = task.errorMessage ? `, Error message: ${task.errorMessage}` : '';
         switch (task.status.toUpperCase()) {
           case 'CANCEL':
           case 'FAILED':
-            throw new Error(`[SQ] Task failed with status ${task.status}, Error message: ${errorMessage}`);
+            throw new Error(`[SQ] Task failed with status ${task.status}${errorInfo}`);
           case 'SUCCESS':
             tl.debug(`[SQ] Task complete: ${JSON.stringify(task)}`);
             return new Task(task);


### PR DESCRIPTION
Related issue: https://community.sonarsource.com/t/sonar-scanner-vsts-provide-error-message-when-sq-task-failed/6556

Currently when Publish Quality Gate Result task failed, we get not informative message that task is failed.
To get more details user have to login in SonarCloud account for investigation and read error message from "Background tasks". For example:

Actual error:
```
Error Details
#11111' is not a valid branch name. It can only contain 'A-Z', 'a-z', '0-9', '-', '_', '.', and '/')
```

In Azure DevOps (VSTS), I see only this not informative message:
```
##[section]Starting: Publish Quality Gate Result
==============================================================================
Task         : Publish Quality Gate Result
Description  : Publish SonarCloud's Quality Gate result on the VSTS/TFS build result, to be used after the actual analysis.
Version      : 1.3.0
Author       : sonarsource
==============================================================================
##[error][SQ] Task failed with status FAILED
##[section]Finishing: Publish Quality Gate Result

```

Expected message in Azure DevOps (VSTS):
```
##[section]Starting: Publish Quality Gate Result
==============================================================================
Task         : Publish Quality Gate Result
Description  : Publish SonarCloud's Quality Gate result on the VSTS/TFS build result, to be used after the actual analysis.
Version      : 1.3.0
Author       : sonarsource
==============================================================================
##[error][SQ] Task failed with status FAILED, Error message: #11111' is not a valid branch name. It can only contain 'A-Z', 'a-z', '0-9', '-', '_', '.', and '/')
##[section]Finishing: Publish Quality Gate Result

```

Changes are based on API documentation:
https://sonarcloud.io/web_api/api/ce/task