### PR TITLE
Fix pull request integration with bitbucketcloud

### DIFF
--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -76,7 +76,11 @@ async function populateBranchAndPrProps(props: { [key: string]: string }) {
       props['sonar.pullrequest.key'] = tl.getVariable('System.PullRequest.PullRequestNumber');
       props['sonar.pullrequest.provider'] = 'github';
       props['sonar.pullrequest.github.repository'] = tl.getVariable(REPO_NAME_VAR);
-    } else {
+    } else if (provider === 'Bitbucket') {
+      props['sonar.pullrequest.provider'] = 'bitbucketcloud';
+      props['sonar.pullrequest.bitbucketcloud.repository'] = tl.getVariable(REPO_NAME_VAR);
+    }
+    else {
       tl.warning(`Unsupported PR provider '${provider}'`);
       props['sonar.scanner.skip'] = 'true';
     }

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -79,8 +79,7 @@ async function populateBranchAndPrProps(props: { [key: string]: string }) {
     } else if (provider === 'Bitbucket') {
       props['sonar.pullrequest.provider'] = 'bitbucketcloud';
       props['sonar.pullrequest.bitbucketcloud.repository'] = tl.getVariable(REPO_NAME_VAR);
-    }
-    else {
+    } else {
       tl.warning(`Unsupported PR provider '${provider}'`);
       props['sonar.scanner.skip'] = 'true';
     }


### PR DESCRIPTION
People can't make it work to enable pull request analyses when using bitbucketcloud in combination with vsts (azure devops). Please see: [https://community.sonarsource.com/t/pull-request-bitbucket-azuredevops-pipelines-sonarcloud-unsupported-pr-provider-bitbucket/7375](https://community.sonarsource.com/t/pull-request-bitbucket-azuredevops-pipelines-sonarcloud-unsupported-pr-provider-bitbucket/7375) or  [https://community.sonarsource.com/t/pull-request-analyses-issue-in-azure-devops-to-sonarcloud-with-bitbucketcloud-as-repository/7494](https://community.sonarsource.com/t/pull-request-analyses-issue-in-azure-devops-to-sonarcloud-with-bitbucketcloud-as-repository/7494)