### PR TITLE
Case insensitive check for Tfs Git repo provider

### DIFF
--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -67,7 +67,7 @@ async function populateBranchAndPrProps(props: { [key: string]: string }) {
     props['sonar.pullrequest.branch'] = branchName(
       tl.getVariable('System.PullRequest.SourceBranch')
     );
-    if (provider === 'TfsGit') {
+    if (provider.toLowerCase() === 'tfsgit') {
       props['sonar.pullrequest.provider'] = 'vsts';
       props['sonar.pullrequest.vsts.instanceUrl'] = collectionUrl;
       props['sonar.pullrequest.vsts.project'] = tl.getVariable('System.TeamProject');
@@ -83,7 +83,7 @@ async function populateBranchAndPrProps(props: { [key: string]: string }) {
   } else {
     let isDefaultBranch = true;
     const currentBranch = tl.getVariable('Build.SourceBranch');
-    if (provider === 'TfsGit') {
+    if (provider.toLowerCase() === 'tfsgit') {
       isDefaultBranch = currentBranch === (await getDefaultBranch(collectionUrl));
     } else if (provider === 'Git' || provider === 'GitHub') {
       // TODO for GitHub we should get the default branch configured on the repo


### PR DESCRIPTION
This PR fixes an issue where the branch and pull request properties are not set correctly when the repository provider is Tfs Git.  More info here:

https://community.sonarsource.com/t/tfs-branch-and-pr-analysis-not-working-due-to-unsupported-pr-provider-tfsgit/7772

This PR performs a case insensitive check for the Tfs Git repository provider to support both Tfs versions where the value is 'TfsGit' and versions where the value is 'tfsgit'.