### PR TITLE
change demand

### DIFF
--- a/extensions/sonarcloud/tasks/analyze/new/task.json
+++ b/extensions/sonarcloud/tasks/analyze/new/task.json
@@ -14,7 +14,7 @@
     "Patch": 0
   },
   "minimumAgentVersion": "2.119.1",
-  "demands": ["JAVA_HOME"],
+  "demands": [],
   "inputs": [],
   "execution": {
     "Node": {

--- a/extensions/sonarcloud/tasks/analyze/new/task.json
+++ b/extensions/sonarcloud/tasks/analyze/new/task.json
@@ -14,7 +14,7 @@
     "Patch": 0
   },
   "minimumAgentVersion": "2.119.1",
-  "demands": ["java"],
+  "demands": ["JAVA_HOME"],
   "inputs": [],
   "execution": {
     "Node": {

--- a/extensions/sonarqube/tasks/analyze/new/task.json
+++ b/extensions/sonarqube/tasks/analyze/new/task.json
@@ -15,7 +15,7 @@
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.119.1",
-  "demands": ["JAVA_HOME"],
+  "demands": [],
   "inputs": [],
   "execution": {
     "Node": {

--- a/extensions/sonarqube/tasks/analyze/new/task.json
+++ b/extensions/sonarqube/tasks/analyze/new/task.json
@@ -15,7 +15,7 @@
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.119.1",
-  "demands": ["java"],
+  "demands": ["JAVA_HOME"],
   "inputs": [],
   "execution": {
     "Node": {


### PR DESCRIPTION
Update demanded agent capability from 'java' to 'JAVA_HOME' to be compliant with newer standards.

- See [Community bug fix](https://community.sonarsource.com/t/azure-devops-hosted-build-java-demanded-capability-not-present/8878)
