### PR TITLE
VSTS-171 - Write SONAR_SCANNER_OPTS env variable if standalone scanner is selected in the Prepare Analysis Task configuration.

### DIFF
--- a/common/ts/__tests__/prepare-task-test.ts
+++ b/common/ts/__tests__/prepare-task-test.ts
@@ -32,9 +32,13 @@ it('should display warning for dedicated extension for Sonarcloud', async () => 
 });
 
 it('should fill SONAR_SCANNER_OPTS environment variable', async () => {
-  const scannerObject = new ScannerCLI(__dirname, {
-    projectSettings: 'dummyProjectKey.properties'
-  }, 'file');
+  const scannerObject = new ScannerCLI(
+    __dirname,
+    {
+      projectSettings: 'dummyProjectKey.properties'
+    },
+    'file'
+  );
 
   jest.spyOn(tl, 'getInput').mockImplementation(() => 'CLI');
   jest.spyOn(Scanner, 'getPrepareScanner').mockImplementation(() => scannerObject);
@@ -43,7 +47,5 @@ it('should fill SONAR_SCANNER_OPTS environment variable', async () => {
 
   await prept.default(SQ_ENDPOINT, __dirname);
 
-  expect(process.env.SONAR_SCANNER_OPTS).toBe(
-    '-Dproject.settings=dummyProjectKey.properties'
-  );
+  expect(process.env.SONAR_SCANNER_OPTS).toBe('-Dproject.settings=dummyProjectKey.properties');
 });

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -46,6 +46,10 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
     })
   );
 
+  if (scannerMode === ScannerMode.CLI) {
+    tl.setVariable('SONAR_SCANNER_OPTS', scanner.toCliProps());
+  }
+
   await scanner.runPrepare();
 }
 

--- a/common/ts/sonarqube/Scanner.ts
+++ b/common/ts/sonarqube/Scanner.ts
@@ -16,6 +16,10 @@ export default class Scanner {
     return {};
   }
 
+  public toCliProps() {
+    return '';
+  }
+
   public async runPrepare() {}
 
   public async runAnalysis() {}
@@ -92,6 +96,16 @@ export class ScannerCLI extends Scanner {
       [PROP_NAMES.PROJECTVERSION]: this.data.projectVersion,
       [PROP_NAMES.PROJECTSOURCES]: this.data.projectSources
     };
+  }
+
+  public toCliProps() {
+    if (this.cliMode === 'file') {
+      return `-D${[PROP_NAMES.PROJECTSETTINGS]}=${this.data.projectSettings}`;
+    }
+    return `-D${[PROP_NAMES.PROJECTKEY]}=${this.data.projectKey} 
+    -D${[PROP_NAMES.PROJECTNAME]}=${this.data.projectName}  
+    -D${[PROP_NAMES.PROJECTVERSION]}=${this.data.projectVersion}
+    -D${[PROP_NAMES.PROJECTSOURCES]}=${this.data.projectSources}`;
   }
 
   public async runAnalysis() {

--- a/common/ts/sonarqube/Scanner.ts
+++ b/common/ts/sonarqube/Scanner.ts
@@ -102,10 +102,11 @@ export class ScannerCLI extends Scanner {
     if (this.cliMode === 'file') {
       return `-D${[PROP_NAMES.PROJECTSETTINGS]}=${this.data.projectSettings}`;
     }
-    return `-D${[PROP_NAMES.PROJECTKEY]}=${this.data.projectKey} 
-    -D${[PROP_NAMES.PROJECTNAME]}=${this.data.projectName}  
-    -D${[PROP_NAMES.PROJECTVERSION]}=${this.data.projectVersion}
-    -D${[PROP_NAMES.PROJECTSOURCES]}=${this.data.projectSources}`;
+    return `-D${[PROP_NAMES.PROJECTKEY]}=${this.data.projectKey} -D${[PROP_NAMES.PROJECTNAME]}=${
+      this.data.projectName
+    } -D${[PROP_NAMES.PROJECTVERSION]}=${this.data.projectVersion} -D${[
+      PROP_NAMES.PROJECTSOURCES
+    ]}=${this.data.projectSources}`;
   }
 
   public async runAnalysis() {

--- a/common/ts/sonarqube/__tests__/Scanner-test.ts
+++ b/common/ts/sonarqube/__tests__/Scanner-test.ts
@@ -1,4 +1,4 @@
-import { ScannerCLI } from '../Scanner';
+import Scanner, { ScannerCLI, ScannerMode } from '../Scanner';
 
 jest.mock('azure-pipelines-task-lib/task', () => ({
   debug: jest.fn(),
@@ -21,4 +21,12 @@ it('should return formated argument string for CLI with manual mode', () => {
   expect(actual).toBe(
     '-Dsonar.projectKey=myprojectKey -Dsonar.projectName=undefined -Dsonar.projectVersion=undefined -Dsonar.sources=undefined'
   );
+});
+
+it('should return empty string for default scanner mode', () => {
+  const scanner = new Scanner(__dirname, ScannerMode.CLI);
+
+  const actual = scanner.toCliProps();
+
+  expect(actual).toBe('');
 });

--- a/common/ts/sonarqube/__tests__/Scanner-test.ts
+++ b/common/ts/sonarqube/__tests__/Scanner-test.ts
@@ -1,24 +1,24 @@
 import { ScannerCLI } from '../Scanner';
-  
-  jest.mock('azure-pipelines-task-lib/task', () => ({
-    debug: jest.fn(),
-    error: jest.fn()
-  }));
 
+jest.mock('azure-pipelines-task-lib/task', () => ({
+  debug: jest.fn(),
+  error: jest.fn()
+}));
 
-  it('should return formated argument string for CLI with file mode', () => {
-    const scanner = new ScannerCLI(__dirname, {projectSettings: "DummyScanner.properties"}, 'file');
+it('should return formated argument string for CLI with file mode', () => {
+  const scanner = new ScannerCLI(__dirname, { projectSettings: 'DummyScanner.properties' }, 'file');
 
-    var actual = scanner.toCliProps();
+  const actual = scanner.toCliProps();
 
-    expect(actual).toBe("-Dproject.settings=DummyScanner.properties");
-  });
+  expect(actual).toBe('-Dproject.settings=DummyScanner.properties');
+});
 
-  
-  it('should return formated argument string for CLI with manual mode', () => {
-    const scanner = new ScannerCLI(__dirname, {projectKey: "myprojectKey"}, 'manual');
+it('should return formated argument string for CLI with manual mode', () => {
+  const scanner = new ScannerCLI(__dirname, { projectKey: 'myprojectKey' }, 'manual');
 
-    var actual = scanner.toCliProps();
+  const actual = scanner.toCliProps();
 
-    expect(actual).toBe("-Dsonar.projectKey=myprojectKey -Dsonar.projectName=undefined -Dsonar.projectVersion=undefined -Dsonar.sources=undefined");
-  });
+  expect(actual).toBe(
+    '-Dsonar.projectKey=myprojectKey -Dsonar.projectName=undefined -Dsonar.projectVersion=undefined -Dsonar.sources=undefined'
+  );
+});

--- a/common/ts/sonarqube/__tests__/Scanner-test.ts
+++ b/common/ts/sonarqube/__tests__/Scanner-test.ts
@@ -1,0 +1,24 @@
+import { ScannerCLI } from '../Scanner';
+  
+  jest.mock('azure-pipelines-task-lib/task', () => ({
+    debug: jest.fn(),
+    error: jest.fn()
+  }));
+
+
+  it('should return formated argument string for CLI with file mode', () => {
+    const scanner = new ScannerCLI(__dirname, {projectSettings: "DummyScanner.properties"}, 'file');
+
+    var actual = scanner.toCliProps();
+
+    expect(actual).toBe("-Dproject.settings=DummyScanner.properties");
+  });
+
+  
+  it('should return formated argument string for CLI with manual mode', () => {
+    const scanner = new ScannerCLI(__dirname, {projectKey: "myprojectKey"}, 'manual');
+
+    var actual = scanner.toCliProps();
+
+    expect(actual).toBe("-Dsonar.projectKey=myprojectKey -Dsonar.projectName=undefined -Dsonar.projectVersion=undefined -Dsonar.sources=undefined");
+  });


### PR DESCRIPTION
This issue was because the call to sonar-scanner cli is done through a wrapper (.bat or not), using SONAR_SCANNER_OPTS environment variable to fill arguments to pass to that CLI. This env variable was never written in the extension, so now it's done. 