### PR TITLE
VSTS-211: Cope with SONAR_SCANNER_OPTS not being defined.

### DIFF
--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -54,7 +54,9 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
 
   if (scannerMode === ScannerMode.CLI) {
     let actualSonarOpts = tl.getVariable('SONAR_SCANNER_OPTS');
-    actualSonarOpts = actualSonarOpts.concat(' ', scanner.toCliProps()).trim();
+    if (actualSonarOpts != undefined) {
+      actualSonarOpts = actualSonarOpts.concat(' ', scanner.toCliProps()).trim();
+    }
     tl.setVariable('SONAR_SCANNER_OPTS', actualSonarOpts);
   }
 


### PR DESCRIPTION
When using the latest version of the Azure DevOps extension, if we don't specify a variable of `SONAR_SCANNER_OPTS` we see the following error during the `SonarQubePrepare` phase:

> ##[error]Cannot read property 'concat' of undefined

This change checks for the variable not be defined.
