### PR TITLE
Log a warning when no analysis was found

### DIFF
--- a/common/ts/publish-task.ts
+++ b/common/ts/publish-task.ts
@@ -36,6 +36,9 @@ export default async function publishTask(endpointType: EndpointType) {
   }
 
   tl.debug(`Number of analyses in this build: ${taskReports.length}`);
+  if (!taskReports.length) {
+    tl.warning('No analyses found in this build! Please check your build configuration.');
+  }
   tl.debug(`Overall Quality Gate status: ${globalQualityGateStatus}`);
 
   fillBuildProperty(globalQualityGateStatus);

--- a/common/ts/publish-task.ts
+++ b/common/ts/publish-task.ts
@@ -35,10 +35,12 @@ export default async function publishTask(endpointType: EndpointType) {
     globalQualityGateStatus = 'ok';
   }
 
-  tl.debug(`Number of analyses in this build: ${taskReports.length}`);
   if (!taskReports.length) {
     tl.warning('No analyses found in this build! Please check your build configuration.');
+  } else {
+    tl.debug(`Number of analyses in this build: ${taskReports.length}`);
   }
+  
   tl.debug(`Overall Quality Gate status: ${globalQualityGateStatus}`);
 
   fillBuildProperty(globalQualityGateStatus);

--- a/common/ts/publish-task.ts
+++ b/common/ts/publish-task.ts
@@ -40,7 +40,7 @@ export default async function publishTask(endpointType: EndpointType) {
   } else {
     tl.debug(`Number of analyses in this build: ${taskReports.length}`);
   }
-  
+
   tl.debug(`Overall Quality Gate status: ${globalQualityGateStatus}`);
 
   fillBuildProperty(globalQualityGateStatus);


### PR DESCRIPTION
Inform users when the publish task did not actually do anything by logging a warning.
