### PR TITLE
VSTS-213 - Report-task.txt new location improvement

### DIFF
--- a/common/ts/__tests__/publish-task-test.ts
+++ b/common/ts/__tests__/publish-task-test.ts
@@ -1,5 +1,6 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import { InvalidApiResourceVersionError } from 'azure-devops-node-api/VsoClient';
+import { SemVer } from 'semver';
 import Analysis from '../sonarqube/Analysis';
 import Endpoint, { EndpointType } from '../sonarqube/Endpoint';
 import Metrics from '../sonarqube/Metrics';
@@ -8,6 +9,7 @@ import TaskReport from '../sonarqube/TaskReport';
 import * as publishTask from '../publish-task';
 import * as serverUtils from '../helpers/azdo-server-utils';
 import * as apiUtils from '../helpers/azdo-api-utils';
+import * as request from '../helpers/request';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -71,6 +73,8 @@ it('check multiple report status and set global quality gate for build propertie
     null,
     null
   );
+
+  jest.spyOn(request, 'getServerVersion').mockResolvedValue(new SemVer('7.2.0'));
 
   jest.spyOn(Analysis, 'getAnalysis').mockResolvedValue(returnedAnalysisOk);
   jest.spyOn(Analysis, 'getAnalysis').mockResolvedValue(returnedAnalysisOk);
@@ -147,6 +151,7 @@ it('check multiple report status and set global quality gate for build propertie
     null,
     null
   );
+  jest.spyOn(request, 'getServerVersion').mockResolvedValue(new SemVer('7.2.0'));
 
   jest.spyOn(Analysis, 'getAnalysis').mockResolvedValueOnce(returnedAnalysisOk);
   jest.spyOn(Analysis, 'getAnalysis').mockResolvedValueOnce(returnedAnalysisError);
@@ -278,6 +283,8 @@ it('task should not fail the task even if all ceTasks timeout', async () => {
   jest.spyOn(tl, 'setResult');
   jest.spyOn(tl, 'debug').mockImplementation(() => null);
   jest.spyOn(tl, 'warning').mockImplementation(() => null);
+
+  jest.spyOn(request, 'getServerVersion').mockResolvedValue(new SemVer('7.2.0'));
 
   tl.setVariable('SONARQUBE_SCANNER_PARAMS', 'anything...');
   tl.setVariable('SONARQUBE_ENDPOINT', SC_ENDPOINT.toJson());

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -30,6 +30,7 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
 
   if (await branchFeatureSupported(endpoint)) {
     await populateBranchAndPrProps(props);
+    props['sonar.scanner.metadataFilePath'] = reportPath();
     tl.debug(`[SQ] Branch and PR parameters: ${JSON.stringify(props)}`);
   }
 
@@ -38,8 +39,6 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
     .filter(keyValue => !keyValue.startsWith('#'))
     .map(keyValue => keyValue.split(/=(.+)/))
     .forEach(([k, v]) => (props[k] = v));
-
-  props['sonar.scanner.metadataFilePath'] = reportPath();
 
   tl.setVariable('SONARQUBE_SCANNER_MODE', scannerMode);
   tl.setVariable('SONARQUBE_ENDPOINT', endpoint.toJson(), true);

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -30,6 +30,11 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
 
   if (await branchFeatureSupported(endpoint)) {
     await populateBranchAndPrProps(props);
+    /* branchFeatureSupported method magically checks everything we need for the support of the below property, 
+    so we keep it like that for now, waiting for a hardening that will refactor this (at least by renaming the method name) */
+    tl.debug(
+      'SonarCloud or SonarQube version >= 7.2.0 detected, setting report-task.txt file to its newest location.'
+    );
     props['sonar.scanner.metadataFilePath'] = reportPath();
     tl.debug(`[SQ] Branch and PR parameters: ${JSON.stringify(props)}`);
   }

--- a/common/ts/publish-task.ts
+++ b/common/ts/publish-task.ts
@@ -5,6 +5,7 @@ import Metrics from './sonarqube/Metrics';
 import Task, { TimeOutReachedError } from './sonarqube/Task';
 import TaskReport from './sonarqube/TaskReport';
 import { publishBuildSummary, fillBuildProperty } from './helpers/azdo-server-utils';
+import { getServerVersion } from './helpers/request';
 
 let globalQualityGateStatus = '';
 
@@ -25,7 +26,8 @@ export default async function publishTask(endpointType: EndpointType) {
   const metrics = await Metrics.getAllMetrics(endpoint);
 
   const timeoutSec = timeoutInSeconds();
-  const taskReports = await TaskReport.createTaskReportsFromFiles();
+  const serverVersion = await getServerVersion(endpoint);
+  const taskReports = await TaskReport.createTaskReportsFromFiles(endpoint, serverVersion);
 
   const analyses = await Promise.all(
     taskReports.map(taskReport => getReportForTask(taskReport, metrics, endpoint, timeoutSec))

--- a/common/ts/sonarqube/TaskReport.ts
+++ b/common/ts/sonarqube/TaskReport.ts
@@ -1,6 +1,9 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as tl from 'azure-pipelines-task-lib/task';
+import * as semver from 'semver';
+import Endpoint, { EndpointType } from './Endpoint';
+import { findMatch } from '../helpers/temp-find-method';
 
 export const REPORT_TASK_NAME = 'report-task.txt';
 export const SONAR_TEMP_DIRECTORY_NAME = 'sonar';
@@ -40,23 +43,34 @@ export default class TaskReport {
     return this.report.dashboardUrl;
   }
 
-  public static findTaskFileReport(): string[] {
-    const taskReportGlob = path.join(
-      SONAR_TEMP_DIRECTORY_NAME,
-      tl.getVariable('Build.BuildNumber'),
-      '**',
-      REPORT_TASK_NAME
-    );
-    const taskReportGlobResult = tl.findMatch(
-      tl.getVariable('Agent.TempDirectory'),
-      taskReportGlob
-    );
+  public static findTaskFileReport(endpoint: Endpoint, serverVersion: semver.SemVer): string[] {
+    let taskReportGlob: string;
+    let taskReportGlobResult: string[];
+
+    if (endpoint.type === EndpointType.SonarQube && serverVersion < semver.parse('7.2.0')) {
+      tl.debug(
+        'SonarQube version < 7.2.0 detected, falling back to default location(s) for report-task.txt file.'
+      );
+      taskReportGlob = path.join('**', REPORT_TASK_NAME);
+      taskReportGlobResult = findMatch(tl.getVariable('Agent.BuildDirectory'), taskReportGlob);
+    } else {
+      taskReportGlob = path.join(
+        SONAR_TEMP_DIRECTORY_NAME,
+        tl.getVariable('Build.BuildNumber'),
+        '**',
+        REPORT_TASK_NAME
+      );
+      taskReportGlobResult = findMatch(tl.getVariable('Agent.TempDirectory'), taskReportGlob);
+    }
+
     tl.debug(`[SQ] Searching for ${taskReportGlob} - found ${taskReportGlobResult.length} file(s)`);
     return taskReportGlobResult;
   }
 
   public static createTaskReportsFromFiles(
-    filePaths = TaskReport.findTaskFileReport()
+    endpoint: Endpoint,
+    serverVersion: semver.SemVer,
+    filePaths = TaskReport.findTaskFileReport(endpoint, serverVersion)
   ): Promise<TaskReport[]> {
     return Promise.all(
       filePaths.map(filePath => {

--- a/common/ts/sonarqube/TaskReport.ts
+++ b/common/ts/sonarqube/TaskReport.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs-extra';
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as semver from 'semver';
 import Endpoint, { EndpointType } from './Endpoint';
-import { findMatch } from '../helpers/temp-find-method';
 
 export const REPORT_TASK_NAME = 'report-task.txt';
 export const SONAR_TEMP_DIRECTORY_NAME = 'sonar';
@@ -52,7 +51,7 @@ export default class TaskReport {
         'SonarQube version < 7.2.0 detected, falling back to default location(s) for report-task.txt file.'
       );
       taskReportGlob = path.join('**', REPORT_TASK_NAME);
-      taskReportGlobResult = findMatch(tl.getVariable('Agent.BuildDirectory'), taskReportGlob);
+      taskReportGlobResult = tl.findMatch(tl.getVariable('Agent.BuildDirectory'), taskReportGlob);
     } else {
       taskReportGlob = path.join(
         SONAR_TEMP_DIRECTORY_NAME,
@@ -60,7 +59,7 @@ export default class TaskReport {
         '**',
         REPORT_TASK_NAME
       );
-      taskReportGlobResult = findMatch(tl.getVariable('Agent.TempDirectory'), taskReportGlob);
+      taskReportGlobResult = tl.findMatch(tl.getVariable('Agent.TempDirectory'), taskReportGlob);
     }
 
     tl.debug(`[SQ] Searching for ${taskReportGlob} - found ${taskReportGlobResult.length} file(s)`);

--- a/common/ts/sonarqube/__tests__/TaskReport-test.ts
+++ b/common/ts/sonarqube/__tests__/TaskReport-test.ts
@@ -2,7 +2,10 @@ import * as path from 'path';
 import { writeFileSync } from 'fs';
 import { fileSync } from 'tmp'; // eslint-disable-line import/no-extraneous-dependencies
 import * as tl from 'azure-pipelines-task-lib/task';
+import * as semver from 'semver';
 import TaskReport from '../TaskReport';
+import Endpoint, { EndpointType } from '../Endpoint';
+import * as tempFindMethods from '../../helpers/temp-find-method';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -21,7 +24,13 @@ serverUrl=http://sonar`,
     }
   );
 
-  const reports = await TaskReport.createTaskReportsFromFiles([tmpReport.name]);
+  const endpoint = new Endpoint(EndpointType.SonarCloud, null);
+
+  const reports = await TaskReport.createTaskReportsFromFiles(
+    endpoint,
+    new semver.SemVer('7.2.0'),
+    [tmpReport.name]
+  );
 
   expect(reports).toHaveLength(1);
   const report = reports[0];
@@ -55,7 +64,13 @@ serverUrl=http://sonar`,
     }
   );
 
-  const reports = await TaskReport.createTaskReportsFromFiles([tmpReport.name, tmpReport2.name]);
+  const endpoint = new Endpoint(EndpointType.SonarCloud, null);
+
+  const reports = await TaskReport.createTaskReportsFromFiles(
+    endpoint,
+    new semver.SemVer('7.2.0'),
+    [tmpReport.name, tmpReport2.name]
+  );
 
   expect(reports).toHaveLength(2);
   expect(reports[0].projectKey).toBe('projectKey1');
@@ -65,12 +80,14 @@ serverUrl=http://sonar`,
   tmpReport2.removeCallback();
 });
 
-it('should find report files', async () => {
+it('should find report files for SonarCloud', async () => {
   // using spyOn so we can reset the original behaviour
   jest.spyOn(tl, 'getVariable').mockImplementation(() => 'mock root search path');
-  jest.spyOn(tl, 'findMatch').mockImplementation(() => ['path1', 'path2']);
+  jest.spyOn(tempFindMethods, 'findMatch').mockImplementation(() => ['path1', 'path2']);
 
-  const reportFiles = await TaskReport.findTaskFileReport();
+  const endpoint = new Endpoint(EndpointType.SonarCloud, null);
+
+  const reportFiles = await TaskReport.findTaskFileReport(endpoint, new semver.SemVer('7.2.0'));
 
   expect(reportFiles.length).toBe(2);
   expect(reportFiles[0]).toBe('path1');
@@ -87,6 +104,66 @@ it('should find report files', async () => {
     '**',
     'report-task.txt'
   );
-  expect(tl.findMatch).toHaveBeenCalledTimes(1);
-  expect(tl.findMatch).toHaveBeenCalledWith('mock root search path', expectedSearchPath);
+  expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
+  expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
+    'mock root search path',
+    expectedSearchPath
+  );
+});
+
+it('should find report files for SonarQube above 7.2.0', async () => {
+  // using spyOn so we can reset the original behaviour
+  jest.spyOn(tl, 'getVariable').mockImplementation(() => 'mock root search path');
+  jest.spyOn(tempFindMethods, 'findMatch').mockImplementation(() => ['path1', 'path2']);
+
+  const endpoint = new Endpoint(EndpointType.SonarQube, null);
+
+  const reportFiles = await TaskReport.findTaskFileReport(endpoint, new semver.SemVer('7.9.0'));
+
+  expect(reportFiles.length).toBe(2);
+  expect(reportFiles[0]).toBe('path1');
+  expect(reportFiles[1]).toBe('path2');
+
+  expect(tl.getVariable).toHaveBeenCalledTimes(2);
+  expect(tl.getVariable).toBeCalledWith('Agent.TempDirectory');
+
+  // Calculate the expected path to take account of different
+  // path separators in Windows/non-Windows
+  const expectedSearchPath = path.join(
+    'sonar',
+    tl.getVariable('Build.BuildNumber'),
+    '**',
+    'report-task.txt'
+  );
+  expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
+  expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
+    'mock root search path',
+    expectedSearchPath
+  );
+});
+
+it('should find report files for SonarQube below 7.2.0', async () => {
+  // using spyOn so we can reset the original behaviour
+  jest.spyOn(tl, 'getVariable').mockImplementation(() => 'mock root search path');
+  jest.spyOn(tempFindMethods, 'findMatch').mockImplementation(() => ['path1', 'path2']);
+
+  const endpoint = new Endpoint(EndpointType.SonarQube, null);
+
+  const reportFiles = await TaskReport.findTaskFileReport(endpoint, new semver.SemVer('7.0.0'));
+
+  expect(reportFiles.length).toBe(2);
+  expect(reportFiles[0]).toBe('path1');
+  expect(reportFiles[1]).toBe('path2');
+
+  expect(tl.getVariable).toHaveBeenCalledTimes(1);
+  expect(tl.getVariable).toBeCalledWith('Agent.BuildDirectory');
+
+  // Calculate the expected path to take account of different
+  // path separators in Windows/non-Windows
+  const expectedSearchPath = path.join('**', 'report-task.txt');
+  expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
+  expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
+    'mock root search path',
+    expectedSearchPath
+  );
 });

--- a/common/ts/sonarqube/__tests__/TaskReport-test.ts
+++ b/common/ts/sonarqube/__tests__/TaskReport-test.ts
@@ -5,7 +5,6 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as semver from 'semver';
 import TaskReport from '../TaskReport';
 import Endpoint, { EndpointType } from '../Endpoint';
-import * as tempFindMethods from '../../helpers/temp-find-method';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -83,7 +82,7 @@ serverUrl=http://sonar`,
 it('should find report files for SonarCloud', async () => {
   // using spyOn so we can reset the original behaviour
   jest.spyOn(tl, 'getVariable').mockImplementation(() => 'mock root search path');
-  jest.spyOn(tempFindMethods, 'findMatch').mockImplementation(() => ['path1', 'path2']);
+  jest.spyOn(tl, 'findMatch').mockImplementation(() => ['path1', 'path2']);
 
   const endpoint = new Endpoint(EndpointType.SonarCloud, null);
 
@@ -104,17 +103,14 @@ it('should find report files for SonarCloud', async () => {
     '**',
     'report-task.txt'
   );
-  expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
-  expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
-    'mock root search path',
-    expectedSearchPath
-  );
+  expect(tl.findMatch).toHaveBeenCalledTimes(1);
+  expect(tl.findMatch).toHaveBeenCalledWith('mock root search path', expectedSearchPath);
 });
 
 it('should find report files for SonarQube above 7.2.0', async () => {
   // using spyOn so we can reset the original behaviour
   jest.spyOn(tl, 'getVariable').mockImplementation(() => 'mock root search path');
-  jest.spyOn(tempFindMethods, 'findMatch').mockImplementation(() => ['path1', 'path2']);
+  jest.spyOn(tl, 'findMatch').mockImplementation(() => ['path1', 'path2']);
 
   const endpoint = new Endpoint(EndpointType.SonarQube, null);
 
@@ -135,17 +131,14 @@ it('should find report files for SonarQube above 7.2.0', async () => {
     '**',
     'report-task.txt'
   );
-  expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
-  expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
-    'mock root search path',
-    expectedSearchPath
-  );
+  expect(tl.findMatch).toHaveBeenCalledTimes(1);
+  expect(tl.findMatch).toHaveBeenCalledWith('mock root search path', expectedSearchPath);
 });
 
 it('should find report files for SonarQube below 7.2.0', async () => {
   // using spyOn so we can reset the original behaviour
   jest.spyOn(tl, 'getVariable').mockImplementation(() => 'mock root search path');
-  jest.spyOn(tempFindMethods, 'findMatch').mockImplementation(() => ['path1', 'path2']);
+  jest.spyOn(tl, 'findMatch').mockImplementation(() => ['path1', 'path2']);
 
   const endpoint = new Endpoint(EndpointType.SonarQube, null);
 
@@ -161,9 +154,6 @@ it('should find report files for SonarQube below 7.2.0', async () => {
   // Calculate the expected path to take account of different
   // path separators in Windows/non-Windows
   const expectedSearchPath = path.join('**', 'report-task.txt');
-  expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
-  expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
-    'mock root search path',
-    expectedSearchPath
-  );
+  expect(tl.findMatch).toHaveBeenCalledTimes(1);
+  expect(tl.findMatch).toHaveBeenCalledWith('mock root search path', expectedSearchPath);
 });

--- a/extensions/sonarcloud/overview.md
+++ b/extensions/sonarcloud/overview.md
@@ -42,7 +42,7 @@ You can monitor the quality gate status of your projects in your favorite dashbo
 
 ![Quality Gate Widget](img/widget.png)
 
-### In Release Pipelines (Preview)
+#### In Release Pipelines (Preview)
 You can check the quality gate status of a build as a pre-deployment gate in release pipelines.
 
 #### In the build summary


### PR DESCRIPTION
newest location of report-task.txt is now dedidated to either SonarCloud or SQ >= 7.2 + Added fallback research to previous folders in case of SQ < 7.2.