### PR TITLE
Save BuildId when preparing

### DIFF
--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -44,6 +44,9 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
     .map(keyValue => keyValue.split(/=(.+)/))
     .forEach(([k, v]) => (props[k] = v));
 
+  // Save BuildId so that the scan can later uniquely be identified in "project_analyses API" or similar
+  props['sonar.buildid'] = tl.getVariable('Build.BuildId');
+  
   tl.setVariable('SONARQUBE_SCANNER_MODE', scannerMode);
   tl.setVariable('SONARQUBE_ENDPOINT', endpoint.toJson(), true);
   tl.setVariable(


### PR DESCRIPTION
The prepare-task saves a `projectVersion` passed to the task a input parameter. This value is shown in SonarQube UI and thus should be human readable. 

I assume the normal flow is to run prepare and scan tasks for each build of the source code. I therefor think it makes sense to save Azure DevOps `Build.BuildId` as part of the prepare-task. This id could be used to uniquely identify the "scan" when using SonarQube "project_analyses" API.