### PR TITLE
Added a flag to indicate wether to use or not Branch Analysis

### DIFF
--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -105,7 +105,8 @@ export async function populateBranchAndPrProps(props: { [key: string]: string })
     } else if (provider === "Svn") {
       isDefaultBranch = currentBranch === "trunk";
     }
-    if (!isDefaultBranch) {
+    let useBranchAnalysis: boolean = tl.getBoolInput('useBranchAnalysis', true);
+    if (useBranchAnalysis && !isDefaultBranch) {      
       // VSTS-165 don't use Build.SourceBranchName
       props["sonar.branch.name"] = branchName(tl.getVariable("Build.SourceBranch"));
     }

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -106,7 +106,8 @@ export async function populateBranchAndPrProps(props: { [key: string]: string })
       isDefaultBranch = currentBranch === "trunk";
     }
     let useBranchAnalysis: boolean = tl.getBoolInput('useBranchAnalysis', true);
-    if (useBranchAnalysis && !isDefaultBranch) {      
+    tl.debug(`Branch Analysis is ${useBranchAnalysis ? 'enabled' : 'disabled'}`);
+    if (useBranchAnalysis && !isDefaultBranch) {
       // VSTS-165 don't use Build.SourceBranchName
       props["sonar.branch.name"] = branchName(tl.getVariable("Build.SourceBranch"));
     }

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -105,8 +105,8 @@ export async function populateBranchAndPrProps(props: { [key: string]: string })
     } else if (provider === "Svn") {
       isDefaultBranch = currentBranch === "trunk";
     }
-    let useBranchAnalysis: boolean = tl.getBoolInput('useBranchAnalysis', true);
-    tl.debug(`Branch Analysis is ${useBranchAnalysis ? 'enabled' : 'disabled'}`);
+    let useBranchAnalysis: boolean = tl.getBoolInput("useBranchAnalysis", true);
+    tl.debug(`Branch Analysis is ${useBranchAnalysis ? "enabled" : "disabled"}`);
     if (useBranchAnalysis && !isDefaultBranch) {
       // VSTS-165 don't use Build.SourceBranchName
       props["sonar.branch.name"] = branchName(tl.getVariable("Build.SourceBranch"));

--- a/extensions/sonarqube/tasks/prepare/new/task.json
+++ b/extensions/sonarqube/tasks/prepare/new/task.json
@@ -144,6 +144,15 @@
       "helpMarkDown":
         "[Additional properties](https://redirect.sonarsource.com/doc/analysis-parameters.html) to be passed to the scanner. Specify each key=value pair on a new line.",
       "groupName": "advanced"
+    },
+    {
+        "name": "useBranchAnalysis",
+        "type": "boolean",
+        "label": "Use Branch Analysis",
+        "defaultValue": "true",
+        "required": false,
+        "helpMarkDown": "Toggle Branch Analysis feature. When enabled, defines `sonar.branch.name` property if target branch is different from default.",
+        "groupName": "advanced"
     }
   ],
   "execution": {


### PR DESCRIPTION
If you are analysing a branch that isn't default branch for current version control system, the "prepare task" sets `sonar.branch.name` property that requires "Branch Analysis" plugin. When using SonarQube Community edition, this plugin isn't available and the analysis task will fail. I've added a boolean field to "prepare task" to indicate if "Branch Analysis" should be executed or not.

Sorry, I'm not familiar with Jest for unit testing. I'd tryed to write a test based on another existing test.

---

Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [X] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [X] Provide a unit test for any code you changed
- [X] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)
