### PR TITLE
VSTS-236 removed warning displayed as error (only for "An illegal ref…

### DIFF
--- a/common/ts/sonarqube/Scanner.ts
+++ b/common/ts/sonarqube/Scanner.ts
@@ -72,6 +72,11 @@ export default class Scanner {
         return;
       }
       data = data.toString().trim();
+      if (data.indexOf("WARNING: An illegal reflective access operation has occurred") !== -1) {
+        //bypass those warning showing as error because they can't be catched for now by Scanner.
+        tl.debug(data);
+        return;
+      }
       tl.command("task.logissue", { type: "error" }, data);
     });
   }


### PR DESCRIPTION
…lective access operation has occurred" which is under control)

Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [x] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)
