### PR TITLE
VSTS-230 - Run under .NET Core 3 [security]

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -9,5 +9,5 @@ exports.scanner = {
   msBuildVersion,
   cliVersion,
   classicUrl: `${scannerUrlCommon}-net46.zip`,
-  dotnetUrl: `${scannerUrlCommon}-netcoreapp2.0.zip`,
+  dotnetUrl: `${scannerUrlCommon}-netcoreapp3.0.zip`,
 };


### PR DESCRIPTION
As .NET Core 2.x and 2.1 are almost end of life.

See https://endoflife.date/dotnetcore

![image](https://user-images.githubusercontent.com/5808377/127326402-4a4edf7e-25d4-4511-9c59-94fdc9849ae6.png)


Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/contributing.md). <!---- **dead link**

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] ~Provide a unit test for any code you changed~ - no code change
- [x] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX) --> https://jira.sonarsource.com/browse/VSTS-230

See also https://community.sonarsource.com/t/when-will-there-be-support-for-net-core-3-in-sonarscanner-for-azure-devops/21167 and https://jira.sonarsource.com/browse/VSTS-230


untested. Not sure how to test.