### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/sonarcloud @mickael-caro-sonarsource
+.github/CODEOWNERS @sonarsource/sonarcloud


### PR DESCRIPTION
Remove individuals

Ownership is to be assumed by a unique team, no individuals.
(https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2169339970/GitHub+Authentication+Authorization#Team-Ownership)

This does not prevent from subscribing individuals like this for instance:
```
* @mickael-caro-sonarsource
# The owner team ; put this at the end of the file
.github/CODEOWNERS @sonarsource/sonarcloud
```