### PR TITLE
VSTS-297 Bump Scanner for .NET to v5.11.0.60783

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,4 @@
-const msBuildVersion = "5.10.0.59947";
+const msBuildVersion = "5.11.0.60783";
 const cliVersion = "4.8.0.2856"; // Has to be the same version as the one embedded in the Scanner for MSBuild
 
 const scannerUrlCommon =

--- a/extensions/sonarcloud/tasks/analyze/v1/task.json
+++ b/extensions/sonarcloud/tasks/analyze/v1/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 35,
+    "Minor": 36,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarcloud/tasks/prepare/v1/task.json
+++ b/extensions/sonarcloud/tasks/prepare/v1/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 32,
+    "Minor": 33,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarcloud/vss-extension.json
+++ b/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/extensions/sonarqube/tasks/analyze/v4/task.json
+++ b/extensions/sonarqube/tasks/analyze/v4/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 33,
+    "Minor": 34,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 10,
+    "Minor": 11,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",

--- a/extensions/sonarqube/tasks/prepare/v4/task.json
+++ b/extensions/sonarqube/tasks/prepare/v4/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 4,
-    "Minor": 33,
+    "Minor": 34,
     "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",

--- a/extensions/sonarqube/tasks/prepare/v5/task.json
+++ b/extensions/sonarqube/tasks/prepare/v5/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 10,
+    "Minor": 11,
     "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
We need to bump the version of the S4NET before the release of SQ 9.9 LTS for Incremental PR Analysis to work for .NET projects.

Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [x] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)
