### PR TITLE
Fix deprecated SQ extension cateogry

### DIFF
--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -21,7 +21,7 @@
   "description": "Detect bugs, vulnerabilities and code smells across project branches and pull requests.",
   "public": true,
   "categories": [
-    "Build and release"
+    "Azure Pipelines"
   ],
   "icons": {
     "default": "extension-icon.png"


### PR DESCRIPTION
These are the categories that are accepted by Azure Marketplace: https://learn.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#required-attributes

When trying to upload a test build of the extension, here is the error shown:
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/efd79832-faea-44a6-b7a2-c9eb601324f5)
