### PR TITLE
Changed default java verion to 17

### DIFF
--- a/extensions/sonarcloud/tasks/analyze/v1/task.json
+++ b/extensions/sonarcloud/tasks/analyze/v1/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 40,
+    "Minor": 41,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarcloud/tasks/analyze/v1/task.json
+++ b/extensions/sonarcloud/tasks/analyze/v1/task.json
@@ -23,14 +23,14 @@
       "name": "jdkversion",
       "type": "pickList",
       "label": "JDK version source for analysis",
-      "defaultValue": "JAVA_HOME_11_X64",
+      "defaultValue": "JAVA_HOME_17_X64",
       "required": true,
       "options": {
           "JAVA_HOME": "Use JAVA_HOME",
           "JAVA_HOME_11_X64": "Use built-in JAVA_HOME_11_X64 (hosted agent)",
           "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)"
       },
-      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_11_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
+      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_17_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
     }
   ],
   "execution": {

--- a/extensions/sonarcloud/vss-extension.json
+++ b/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 15,
+    "Minor": 16,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -24,14 +24,14 @@
       "name": "jdkversion",
       "type": "pickList",
       "label": "JDK version source for analysis",
-      "defaultValue": "JAVA_HOME_11_X64",
+      "defaultValue": "JAVA_HOME_17_X64",
       "required": true,
       "options": {
         "JAVA_HOME": "Use JAVA_HOME",
         "JAVA_HOME_11_X64": "Use built-in JAVA_HOME_11_X64 (hosted agent)",
         "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)"
       },
-      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_11_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
+      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_17_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
     }
   ],
   "execution": {

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)

**Problem:**
I'm getting a sonar warning as a comment in Pull Requests  in azure devops when running analysis:
> SonarCloud analysis warning for project "SonarProjectName"
The version of Java (11.0.19) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.

**Cause:** 
Currently, the default java version for the analysis task is set to 11. But [Sonarcloud considers it as deprecated](https://docs.sonarcloud.io/appendices/scanner-environment/):
> JDK 11 is deprecated for scanner environments. If you follow these examples, we recommend using the minimum recommended version mentioned at the top of this page.

And the minimum recommended version is 17.

**Fix:**
Luckily, I could change the version via `jdkVersion` parameter. But I will have to do it for all the projects.
So, since the 11 will no longer be supported soon, here is the PR to change the default version to 17.
