### PR TITLE
VSTS-310 Use sonar.token instead of login for SonarCloud

### DIFF
--- a/commonv5/ts/sonarqube/Endpoint.ts
+++ b/commonv5/ts/sonarqube/Endpoint.ts
@@ -38,9 +38,11 @@ export default class Endpoint {
   }
 
   public toSonarProps(serverVersion: semver.SemVer | string) {
-    const authKey = semver.satisfies(serverVersion, "<10.0.0")
-      ? PROP_NAMES.LOGIN
-      : PROP_NAMES.TOKEN;
+    const isSonarCloud = Boolean(this.data.token);
+    const authKey =
+      !isSonarCloud && semver.satisfies(serverVersion, "<10.0.0")
+        ? PROP_NAMES.LOGIN
+        : PROP_NAMES.TOKEN;
 
     return {
       [PROP_NAMES.HOST_URL]: this.data.url,

--- a/commonv5/ts/sonarqube/Endpoint.ts
+++ b/commonv5/ts/sonarqube/Endpoint.ts
@@ -38,11 +38,9 @@ export default class Endpoint {
   }
 
   public toSonarProps(serverVersion: semver.SemVer | string) {
-    const isSonarCloud = Boolean(this.data.token);
-    const authKey =
-      isSonarCloud || semver.satisfies(serverVersion, "<10.0.0")
-        ? PROP_NAMES.LOGIN
-        : PROP_NAMES.TOKEN;
+    const authKey = semver.satisfies(serverVersion, "<10.0.0")
+      ? PROP_NAMES.LOGIN
+      : PROP_NAMES.TOKEN;
 
     return {
       [PROP_NAMES.HOST_URL]: this.data.url,

--- a/commonv5/ts/sonarqube/__tests__/Endpoint-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/Endpoint-test.ts
@@ -80,8 +80,8 @@ it("For SonarQube version < 10.0.0 login is used", () => {
   expect(result.toSonarProps("9.9.1")[PROP_NAMES.LOGIN]).toBe("tokenvalue");
 });
 
-// VSTS-302
-it("On SonarCloud login field is used instead of token", () => {
+// VSTS-302 + VSTS-310
+it("On SonarCloud token field is used instead of login", () => {
   jest.spyOn(tl, "getEndpointUrl").mockImplementation(() => "https://sonarcloud.io");
   jest.spyOn(tl, "getEndpointAuthorizationParameter").mockReturnValueOnce("tokenvalue");
   jest.spyOn(tl, "getEndpointAuthorizationParameter").mockReturnValueOnce("");
@@ -90,5 +90,5 @@ it("On SonarCloud login field is used instead of token", () => {
 
   const result = Endpoint.getEndpoint("sonarcloud", EndpointType.SonarCloud);
 
-  expect(result.toSonarProps("10.0.0")[PROP_NAMES.LOGIN]).toBe("tokenvalue");
+  expect(result.toSonarProps("8.2.4")).not.toContain(PROP_NAMES.LOGIN);
 });

--- a/extensions/sonarcloud/tasks/prepare/v1/task.json
+++ b/extensions/sonarcloud/tasks/prepare/v1/task.json
@@ -11,7 +11,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 37,
+    "Minor": 38,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
Extension version and analyze task bumps happened in the VSTS-311 PR that was merged earlier today. 

Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)
