### PR TITLE
[NO-JIRA] Refactor build process

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -5,19 +5,19 @@ const fs = require('fs-extra');
 // https://github.com/facebookincubator/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd());
 
-function resolveApp(relativePath) {
+function resolveRelativePath(relativePath) {
   return path.resolve(appDirectory, relativePath);
 }
-exports.resolveApp = resolveApp;
+exports.resolveRelativePath = resolveRelativePath;
 
 exports.pathAllFiles = function(...paths) {
   return path.join(...paths, '**', '*');
 };
 
-const buildPath = resolveApp('build');
-const commonPath = resolveApp('common');
-const commonv5Path = resolveApp('commonv5');
-const extensionsPath = resolveApp('extensions');
+const buildPath = resolveRelativePath('build');
+const commonPath = resolveRelativePath('common');
+const commonv5Path = resolveRelativePath('commonv5');
+const extensionsPath = resolveRelativePath('extensions');
 
 exports.paths = {
   root: appDirectory,


### PR DESCRIPTION
Minor code reorganizations and comments to ease understanding of what is happening during the build process, including with downloading msbuild scanners and extracting cli scanner. There _should not_ be any functional changes.

- Moved utilities out of gulpfile into config/utils
- Renamed some misleading gulp task names
- Added comments around code that downloads and extract scanners & reorder code semantically (per scanner kind)
