### PR TITLE
VSTS-320 Fix populating of sonar.branch.name in Community edition

### DIFF
--- a/commonv5/ts/__tests__/prepare-task-test.ts
+++ b/commonv5/ts/__tests__/prepare-task-test.ts
@@ -27,6 +27,7 @@ it("should display warning for dedicated extension for Sonarcloud", async () => 
   jest.spyOn(Scanner, "getPrepareScanner").mockImplementation(() => scannerObject);
   jest.spyOn(scannerObject, "runPrepare").mockImplementation(() => null);
   jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("7.2.0"));
+  jest.spyOn(prept, "getDefaultBranch").mockResolvedValue("refs/heads/master");
 
   await prept.default(SQ_ENDPOINT, __dirname);
 

--- a/commonv5/ts/helpers/request.ts
+++ b/commonv5/ts/helpers/request.ts
@@ -29,8 +29,14 @@ export function get(endpoint: Endpoint, path: string, query?: RequestData): Prom
     .catch((error) => {
       if (error.response) {
         tl.debug(`[SQ] API GET '${path}' failed, status code was: ${error.response.status}`);
+        tl.debug(`API GET error response data: ${JSON.stringify(error.response.data)}`);
       } else {
         tl.debug(`[SQ] API GET '${path}' failed, error is ${error.message}`);
+      }
+      try {
+        tl.debug(`API GET error object: ${JSON.stringify(error)}`);
+      } catch {
+        //noop
       }
       throw new Error(`[SQ] API GET '${path}' failed, error is ${error.message}`);
     });

--- a/extensions/sonarcloud/tasks/analyze/v1/task.json
+++ b/extensions/sonarcloud/tasks/analyze/v1/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 42,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "demands": [

--- a/extensions/sonarcloud/tasks/prepare/v1/task.json
+++ b/extensions/sonarcloud/tasks/prepare/v1/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 39,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Prepare analysis on SonarCloud",

--- a/extensions/sonarcloud/tasks/publish/v1/task.json
+++ b/extensions/sonarcloud/tasks/publish/v1/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 14,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "inputs": [

--- a/extensions/sonarcloud/vss-extension.json
+++ b/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "1.43.0",
+  "version": "1.43.1",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 16,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/prepare/v5/task.json
+++ b/extensions/sonarqube/tasks/prepare/v5/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 16,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/publish/v5/task.json
+++ b/extensions/sonarqube/tasks/publish/v5/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 3,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "inputs": [

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.16.0",
+  "version": "5.16.1",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
This PR reverts changes being done to `sonar.branch.name`.  However, to not pollute users with the permission warning, I use debug instead.