### PR TITLE
[NO-JIRA] Fix axios sending custom user agent to SonarQube instance

### DIFF
--- a/commonv5/ts/helpers/request.ts
+++ b/commonv5/ts/helpers/request.ts
@@ -18,6 +18,9 @@ export function get(endpoint: Endpoint, path: string, query?: RequestData): Prom
       username: endpoint.auth.user,
       password: endpoint.auth.pass,
     },
+    headers: {
+      "User-Agent": undefined,
+    },
     params: query,
     timeout: 60000,
   })

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 17,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/prepare/v5/task.json
+++ b/extensions/sonarqube/tasks/prepare/v5/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 17,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/publish/v5/task.json
+++ b/extensions/sonarqube/tasks/publish/v5/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 5,
     "Minor": 4,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "inputs": [

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.17.0",
+  "version": "5.17.1",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
As part of a recent [dependency upgrade sprint](https://github.com/SonarSource/sonar-scanner-vsts/pull/291), the obsolete request library was changed to axios. 

Axios is sending, by default, is sending its user agent to SonarQube instance. While this is not an issue for SQ, some specific and custom setups with reverse proxy may reject requests from Azure CI before they reach the SQ instance, based on this HTTP header  `User-Agent: axios/0.27.2`.

This PR resets this user agent so that it is not sent (corresponding to the behavior before `5.16.0`). 