### PR TITLE
VSTS-328 Allow local scanner archives to be used at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,8 @@ coverage/
 # eslint
 eslint-report.json
 
+# MacOS
 .DS_Store
+
+# Custom scanners
+/*.zip

--- a/config/config.js
+++ b/config/config.js
@@ -1,13 +1,13 @@
 const msBuildVersion = "5.14.0.78575";
 const cliVersion = "4.8.1.3023"; // Has to be the same version as the one embedded in the Scanner for MSBuild
 
-const scannerUrlCommon =
-  `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${msBuildVersion}/` +
-  `sonar-scanner-msbuild-${msBuildVersion}`;
+const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${msBuildVersion}/`;
+const classicScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-net46.zip`;
+const dotnetScannerFilename = `sonar-scanner-msbuild-${msBuildVersion}-netcoreapp3.0.zip`;
 
 exports.scanner = {
   msBuildVersion,
   cliVersion,
-  classicUrl: `${scannerUrlCommon}-net46.zip`,
-  dotnetUrl: `${scannerUrlCommon}-netcoreapp3.0.zip`,
+  classicUrl: scannersLocation + classicScannerFilename,
+  dotnetUrl: scannersLocation + dotnetScannerFilename,
 };

--- a/config/utils.js
+++ b/config/utils.js
@@ -8,6 +8,7 @@ const exec = require('gulp-exec');
 const dateformat = require('dateformat');
 const mergeStream = require('merge-stream');
 const gulpRename = require('gulp-rename');
+const gulpDownload = require('gulp-download');
 const map = require('map-stream');
 const gulpDel = require('del');
 const globby = require('globby');
@@ -40,6 +41,16 @@ function run(cl, options = {}) {
   return (output || '').toString().trim();
 }
 exports.run = run;
+
+// Return a stream that downloads the file if urlOrPath is a link, or copies it otherwise (if it is a relaitve path)
+function downloadOrCopy(urlOrPath) {
+  if (urlOrPath.startsWith('http')) {
+    return gulpDownload(urlOrPath);
+  } else {
+    return gulp.src(urlOrPath);
+  }
+}
+exports.downloadOrCopy = downloadOrCopy;
 
 function npmInstall(packagePath) {
   run(`cd ${path.dirname(packagePath)} && npm install && cd ${paths.root}`);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ const request = require('request');
 const yargs = require('yargs');
 const artifactoryUpload = require('gulp-artifactory-upload');
 const decompress = require('gulp-decompress');
-const download = require('gulp-download');
 const gulp = require('gulp');
 const gulpDel = require('del');
 const gulpRename = require('gulp-rename');
@@ -27,7 +26,8 @@ const {
   runSonnarQubeScannerForSonarCloud,
   tfxCommand,
   copyIconsTask,
-  cycloneDxPipe
+  cycloneDxPipe,
+  downloadOrCopy
 } = require('./config/utils');
 const { scanner } = require('./config/config');
 const { gulpSign: getSignature } = require('./config/gulp-sign.js');
@@ -336,11 +336,11 @@ gulp.task('tasks:document-tasks-version', () => {
  * Download scanners
  */
 gulp.task('scanner:download', () => {
-  const classicDownload = download(scanner.classicUrl)
+  const classicDownload = downloadOrCopy(scanner.classicUrl)
     .pipe(decompress())
     .pipe(gulp.dest(paths.build.classicScanner));
 
-  const dotnetDownload = download(scanner.dotnetUrl)
+  const dotnetDownload = downloadOrCopy(scanner.dotnetUrl)
     .pipe(decompress())
     .pipe(gulp.dest(paths.build.dotnetScanner));
 


### PR DESCRIPTION
This PR eases including custom scanner archives in extension test builds. Before this PR, it was only possible to download scanners from the URL passed in `config.js`. It is now possible to use a relative path to include local scanner archives in the extension build.

Steps:
1. Modify `config/config.js` and set `scannersLocation = './'`
2. Ensure you have scanners named `sonar-scanner-msbuild-${msBuildVersion}-net46.zip` and `sonar-scanner-msbuild-${msBuildVersion}-netcoreapp3.0.zip` in the extension/repository root folder
3. Build the extension as usual, eg `npm run build`

The extension will be built with the custom scanners that you specified. 
The previous behavior is left intact. The default behavior is still to fetch the specified release from GitHub.