### PR TITLE
Fix ESLint & Prettier configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -119,13 +119,11 @@
     "import/no-deprecated": "error",
     "import/no-duplicates": "error",
     "import/no-dynamic-require": "error",
-    "import/no-extraneous-dependencies": ["error", { "packageDir": ["./", "./common/ts"] }],
     "import/no-mutable-exports": "error",
     "import/no-named-as-default": "error",
     "import/no-named-as-default-member": "error",
     "import/no-named-default": "error",
     "import/no-webpack-loader-syntax": "error",
-    "import/order": ["error", { "groups": ["builtin", "external"], "newlines-between": "never" }],
 
     // does not properly work with ts
     "import/no-unresolved": "off",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/common/ts/__tests__/analyze-task-test.ts
+++ b/common/ts/__tests__/analyze-task-test.ts
@@ -6,7 +6,7 @@ it("should not have SONARQUBE_SCANNER_MODE property filled", async () => {
   jest.spyOn(tl, "getVariable").mockImplementation(() => undefined);
 
   const expectedError = new Error(
-    "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task"
+    "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task",
   );
   try {
     await analyze.default(__dirname);
@@ -38,7 +38,7 @@ it("should run scanner", async () => {
   jest
     .spyOn(tl, "getVariable")
     .mockReturnValueOnce(
-      '{"type":"SonarQube","data":{"url":"https://sonarqube.com/","username":"token"}}'
+      '{"type":"SonarQube","data":{"url":"https://sonarqube.com/","username":"token"}}',
     );
 
   jest.spyOn(scanner, "runAnalysis").mockImplementation(() => null);

--- a/common/ts/__tests__/prepare-task-test.ts
+++ b/common/ts/__tests__/prepare-task-test.ts
@@ -1,10 +1,10 @@
-import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import { Guid } from "guid-typescript";
+import * as path from "path";
 import { SemVer } from "semver";
-import Endpoint, { EndpointType } from "../sonarqube/Endpoint";
-import * as prept from "../prepare-task";
 import * as request from "../helpers/request";
+import * as prept from "../prepare-task";
+import Endpoint, { EndpointType } from "../sonarqube/Endpoint";
 import Scanner, { ScannerMSBuild } from "../sonarqube/Scanner";
 
 beforeEach(() => {
@@ -32,7 +32,7 @@ it("should display warning for dedicated extension for Sonarcloud", async () => 
   await prept.default(SQ_ENDPOINT, __dirname);
 
   expect(tl.warning).toHaveBeenCalledWith(
-    "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud"
+    "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud",
   );
 });
 
@@ -50,7 +50,7 @@ it("should build report task path from variables", () => {
     sonarSubDirectory,
     buildNumber,
     guid.toString(),
-    "report-task.txt"
+    "report-task.txt",
   );
 
   jest.spyOn(tl, "getVariable").mockImplementationOnce(() => reportDirectory);

--- a/common/ts/__tests__/publish-task-test.ts
+++ b/common/ts/__tests__/publish-task-test.ts
@@ -1,15 +1,15 @@
-import * as tl from "azure-pipelines-task-lib/task";
 import { InvalidApiResourceVersionError } from "azure-devops-node-api/VsoClient";
+import * as tl from "azure-pipelines-task-lib/task";
 import { SemVer } from "semver";
+import * as apiUtils from "../helpers/azdo-api-utils";
+import * as serverUtils from "../helpers/azdo-server-utils";
+import * as request from "../helpers/request";
+import * as publishTask from "../publish-task";
 import Analysis from "../sonarqube/Analysis";
 import Endpoint, { EndpointType } from "../sonarqube/Endpoint";
 import Metrics from "../sonarqube/Metrics";
 import Task, { TimeOutReachedError } from "../sonarqube/Task";
 import TaskReport from "../sonarqube/TaskReport";
-import * as publishTask from "../publish-task";
-import * as serverUtils from "../helpers/azdo-server-utils";
-import * as apiUtils from "../helpers/azdo-api-utils";
-import * as request from "../helpers/request";
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -36,7 +36,7 @@ it("should fail unless SONARQUBE_SCANNER_PARAMS are supplied", async () => {
   expect(tl.getVariable).toBeCalledWith("SONARQUBE_SCANNER_PARAMS");
   expect(tl.setResult).toBeCalledWith(
     tl.TaskResult.Failed,
-    "The SonarCloud Prepare Analysis Configuration must be added."
+    "The SonarCloud Prepare Analysis Configuration must be added.",
   );
 });
 
@@ -73,7 +73,7 @@ it("check multiple report status and set global quality gate for build propertie
     [],
     "",
     null,
-    null
+    null,
   );
 
   jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("7.2.0"));
@@ -140,7 +140,7 @@ it("check multiple report status and set global quality gate for build propertie
     [],
     "",
     null,
-    null
+    null,
   );
 
   const returnedAnalysisError = new Analysis(
@@ -149,7 +149,7 @@ it("check multiple report status and set global quality gate for build propertie
     [],
     "",
     null,
-    null
+    null,
   );
   jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("7.2.0"));
 
@@ -194,7 +194,7 @@ it("get report string should return undefined if ceTask times out", async () => 
   expect(result).toBeUndefined();
   expect(Task.waitForTaskCompletion).toHaveBeenCalledWith(SQ_ENDPOINT, TASK_REPORT.ceTaskId, 999);
   expect(tl.warning).toBeCalledWith(
-    "Task '111' takes too long to complete. Stopping after 999s of polling. No quality gate will be displayed on build result."
+    "Task '111' takes too long to complete. Stopping after 999s of polling. No quality gate will be displayed on build result.",
   );
   expect(Analysis.getAnalysis).not.toBeCalled();
 });
@@ -233,7 +233,7 @@ it("get report string for single report", async () => {
     [],
     "",
     null,
-    null
+    null,
   );
   jest.spyOn(Analysis, "getAnalysis").mockResolvedValue(returnedAnalysis);
   jest.spyOn(returnedAnalysis, "getHtmlAnalysisReport").mockImplementation(() => "dummy html");
@@ -306,7 +306,7 @@ it("task should not fail the task even if all ceTasks timeout", async () => {
     () =>
       new Promise((resolve) => {
         return resolve();
-      })
+      }),
   );
 
   await publishTask.default(EndpointType.SonarCloud);
@@ -318,9 +318,9 @@ it("task should not fail the task even if all ceTasks timeout", async () => {
   expect(serverUtils.publishBuildSummary).toBeCalledWith("\r\n", EndpointType.SonarCloud);
 
   expect(tl.warning).toBeCalledWith(
-    "Task '111' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result."
+    "Task '111' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result.",
   );
   expect(tl.warning).toBeCalledWith(
-    "Task '222' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result."
+    "Task '222' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result.",
   );
 });

--- a/common/ts/analyze-task.ts
+++ b/common/ts/analyze-task.ts
@@ -1,20 +1,20 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Scanner, { ScannerMode } from "./sonarqube/Scanner";
 import JavaVersionResolver from "./helpers/java-version-resolver";
-import { EndpointType, EndpointData } from "./sonarqube/Endpoint";
-import { sanitizeVariable, PROP_NAMES } from "./helpers/utils";
+import { PROP_NAMES, sanitizeVariable } from "./helpers/utils";
+import { EndpointData, EndpointType } from "./sonarqube/Endpoint";
+import Scanner, { ScannerMode } from "./sonarqube/Scanner";
 
 const JAVA_11_PATH_ENV_NAME = "JAVA_HOME_11_X64";
 
 export default async function analyzeTask(
   rootPath: string,
   _jdkVersionSource: string = "",
-  isSonarCloud: boolean = false
+  isSonarCloud: boolean = false,
 ) {
   const scannerMode: ScannerMode = ScannerMode[tl.getVariable("SONARQUBE_SCANNER_MODE")];
   if (!scannerMode) {
     throw new Error(
-      "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task"
+      "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task",
     );
   }
   Scanner.setIsSonarCloud(isSonarCloud);
@@ -24,7 +24,7 @@ export default async function analyzeTask(
   sqScannerParams = JSON.parse(sqScannerParams);
 
   const endpointData: { type: EndpointType; data: EndpointData } = JSON.parse(
-    tl.getVariable("SONARQUBE_ENDPOINT")
+    tl.getVariable("SONARQUBE_ENDPOINT"),
   );
   if (endpointData.data.token && endpointData.data.token.length > 0) {
     sqScannerParams[PROP_NAMES.LOGIN] = endpointData.data.token;

--- a/common/ts/helpers/__tests__/utils-test.ts
+++ b/common/ts/helpers/__tests__/utils-test.ts
@@ -13,8 +13,8 @@ describe("sanitizeVariable", () => {
   it("should sanitize username and pass", () => {
     expect(
       sanitizeVariable(
-        '{ "foo": "a", "bar": "b", "sonar.login": "aaabbbccc", "sonar.password": "fffjjjkkk" }'
-      )
+        '{ "foo": "a", "bar": "b", "sonar.login": "aaabbbccc", "sonar.password": "fffjjjkkk" }',
+      ),
     ).toBe('{"foo":"a","bar":"b"}');
   });
 });

--- a/common/ts/helpers/azdo-api-utils.ts
+++ b/common/ts/helpers/azdo-api-utils.ts
@@ -1,10 +1,10 @@
-import * as tl from "azure-pipelines-task-lib/task";
 import * as vm from "azure-devops-node-api";
 import {
   JsonPatchDocument,
   JsonPatchOperation,
   Operation,
 } from "azure-devops-node-api/interfaces/common/VSSInterfaces";
+import * as tl from "azure-pipelines-task-lib/task";
 
 export interface IPropertyBag {
   propertyName: string;
@@ -41,7 +41,7 @@ export async function addBuildProperty(properties: IPropertyBag[]) {
   } catch (exception) {
     tl.warning(
       "Failed to create a build property. Not blocking unless you are using the Sonar Pre-Deployment gate in Release Pipelines. Exception : " +
-        exception
+        exception,
     );
   }
 }

--- a/common/ts/helpers/azdo-server-utils.ts
+++ b/common/ts/helpers/azdo-server-utils.ts
@@ -28,7 +28,7 @@ export function uploadBuildSummary(summaryPath: string, title: string): void {
       type: "Distributedtask.Core.Summary",
       name: title,
     },
-    summaryPath
+    summaryPath,
   );
 }
 

--- a/common/ts/helpers/measures.ts
+++ b/common/ts/helpers/measures.ts
@@ -7,7 +7,7 @@ interface Formatter {
 export function formatMeasure(
   value: string | number | undefined,
   type: string,
-  options?: any
+  options?: any,
 ): string {
   const formatter = getFormatter(type);
   return useFormatter(value, formatter, options);
@@ -16,7 +16,7 @@ export function formatMeasure(
 function useFormatter(
   value: string | number | undefined,
   formatter: Formatter,
-  options?: any
+  options?: any,
 ): string {
   return value !== undefined && value !== "" ? formatter(value, options) : "";
 }
@@ -40,7 +40,7 @@ function getFormatter(type: string): Formatter {
 function numberFormatter(
   value: number,
   minimumFractionDigits = 0,
-  maximumFractionDigits = minimumFractionDigits
+  maximumFractionDigits = minimumFractionDigits,
 ) {
   const { format } = new Intl.NumberFormat("en-US", {
     minimumFractionDigits,
@@ -172,7 +172,7 @@ function formatDurationShort(
   isNegative: boolean,
   days: number,
   hours: number,
-  minutes: number
+  minutes: number,
 ): string {
   if (shouldDisplayDaysInShortFormat(days)) {
     const roundedDays = Math.round(days);
@@ -184,7 +184,7 @@ function formatDurationShort(
     const roundedHours = Math.round(hours);
     const formattedHours = formatMeasure(
       isNegative ? -1 * roundedHours : roundedHours,
-      "SHORT_INT"
+      "SHORT_INT",
     );
     return formattedHours + "h";
   }

--- a/common/ts/helpers/request.ts
+++ b/common/ts/helpers/request.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
-import * as semver from "semver";
 import * as tl from "azure-pipelines-task-lib/task";
+import * as semver from "semver";
 import Endpoint from "../sonarqube/Endpoint";
 
 interface RequestData {

--- a/common/ts/helpers/temp-find-method.ts
+++ b/common/ts/helpers/temp-find-method.ts
@@ -65,7 +65,7 @@ export function findMatch(
   defaultRoot: string,
   patterns: string[] | string,
   findOptions?: tl.FindOptions,
-  matchOptions?: tl.MatchOptions
+  matchOptions?: tl.MatchOptions,
 ): string[] {
   // apply defaults for parameters and trace
   defaultRoot = defaultRoot || tl.getVariable("system.defaultWorkingDirectory") || process.cwd();
@@ -159,7 +159,7 @@ export function findMatch(
         let findInfo: im._PatternFindInfo = im._getFindInfoFromPattern(
           defaultRoot,
           pattern,
-          matchOptions
+          matchOptions,
         );
         let findPath: string = findInfo.findPath;
         tl.debug(`findPath: '${findPath}'`);
@@ -225,7 +225,7 @@ export function findMatch(
         let matchResults: string[] = minimatch.match(
           Object.keys(results).map((key: string) => results[key]),
           pattern,
-          matchOptions
+          matchOptions,
         );
         tl.debug(matchResults.length + " matches");
 

--- a/common/ts/helpers/utils.ts
+++ b/common/ts/helpers/utils.ts
@@ -15,7 +15,7 @@ export const PROP_NAMES = {
 export function toCleanJSON(props: { [key: string]: string | undefined }) {
   return JSON.stringify(
     props,
-    Object.keys(props).filter((key) => props[key] != null)
+    Object.keys(props).filter((key) => props[key] != null),
   );
 }
 

--- a/common/ts/prepare-task.ts
+++ b/common/ts/prepare-task.ts
@@ -1,12 +1,12 @@
-import * as path from "path";
-import * as semver from "semver";
 import * as tl from "azure-pipelines-task-lib/task";
 import { Guid } from "guid-typescript";
+import * as path from "path";
+import * as semver from "semver";
+import * as azdoApiUtils from "./helpers/azdo-api-utils";
+import { getServerVersion } from "./helpers/request";
+import { toCleanJSON } from "./helpers/utils";
 import Endpoint, { EndpointType } from "./sonarqube/Endpoint";
 import Scanner, { ScannerMode } from "./sonarqube/Scanner";
-import { toCleanJSON } from "./helpers/utils";
-import { getServerVersion } from "./helpers/request";
-import * as azdoApiUtils from "./helpers/azdo-api-utils";
 import { REPORT_TASK_NAME, SONAR_TEMP_DIRECTORY_NAME } from "./sonarqube/TaskReport";
 
 const REPO_NAME_VAR = "Build.Repository.Name";
@@ -18,7 +18,7 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
       endpoint.url.startsWith("https://sonarqube.com"))
   ) {
     tl.warning(
-      "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud"
+      "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud",
     );
   }
 
@@ -32,7 +32,7 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
     /* branchFeatureSupported method magically checks everything we need for the support of the below property, 
     so we keep it like that for now, waiting for a hardening that will refactor this (at least by renaming the method name) */
     tl.debug(
-      "SonarCloud or SonarQube version >= 7.2.0 detected, setting report-task.txt file to its newest location."
+      "SonarCloud or SonarQube version >= 7.2.0 detected, setting report-task.txt file to its newest location.",
     );
     props["sonar.scanner.metadataFilePath"] = reportPath();
     tl.debug(`[SQ] Branch and PR parameters: ${JSON.stringify(props)}`);
@@ -73,7 +73,7 @@ export async function populateBranchAndPrProps(props: { [key: string]: string })
     props["sonar.pullrequest.key"] = prId;
     props["sonar.pullrequest.base"] = branchName(tl.getVariable("System.PullRequest.TargetBranch"));
     props["sonar.pullrequest.branch"] = branchName(
-      tl.getVariable("System.PullRequest.SourceBranch")
+      tl.getVariable("System.PullRequest.SourceBranch"),
     );
     if (provider === "TfsGit") {
       props["sonar.pullrequest.provider"] = "vsts";
@@ -127,7 +127,7 @@ export function reportPath(): string {
     SONAR_TEMP_DIRECTORY_NAME,
     tl.getVariable("Build.BuildNumber"),
     Guid.create().toString(),
-    REPORT_TASK_NAME
+    REPORT_TASK_NAME,
   );
 }
 
@@ -143,7 +143,7 @@ export async function getDefaultBranch(collectionUrl: string) {
     const gitApi = await vsts.getGitApi();
     const repo = await gitApi.getRepository(
       tl.getVariable(REPO_NAME_VAR),
-      tl.getVariable("System.TeamProject")
+      tl.getVariable("System.TeamProject"),
     );
     tl.debug(`Default branch of this repository is '${repo.defaultBranch}'`);
     return repo.defaultBranch;

--- a/common/ts/publish-task.ts
+++ b/common/ts/publish-task.ts
@@ -1,11 +1,11 @@
 import * as tl from "azure-pipelines-task-lib/task";
+import { fillBuildProperty, publishBuildSummary } from "./helpers/azdo-server-utils";
+import { getServerVersion } from "./helpers/request";
 import Analysis from "./sonarqube/Analysis";
-import Endpoint, { EndpointType, EndpointData } from "./sonarqube/Endpoint";
+import Endpoint, { EndpointData, EndpointType } from "./sonarqube/Endpoint";
 import Metrics from "./sonarqube/Metrics";
 import Task, { TimeOutReachedError } from "./sonarqube/Task";
 import TaskReport from "./sonarqube/TaskReport";
-import { publishBuildSummary, fillBuildProperty } from "./helpers/azdo-server-utils";
-import { getServerVersion } from "./helpers/request";
 
 let globalQualityGateStatus = "";
 
@@ -14,13 +14,13 @@ export default async function publishTask(endpointType: EndpointType) {
   if (!params) {
     tl.setResult(
       tl.TaskResult.Failed,
-      `The ${endpointType} Prepare Analysis Configuration must be added.`
+      `The ${endpointType} Prepare Analysis Configuration must be added.`,
     );
     return;
   }
 
   const endpointData: { type: EndpointType; data: EndpointData } = JSON.parse(
-    tl.getVariable("SONARQUBE_ENDPOINT")
+    tl.getVariable("SONARQUBE_ENDPOINT"),
   );
   const endpoint = new Endpoint(endpointData.type, endpointData.data);
   const metrics = await Metrics.getAllMetrics(endpoint);
@@ -30,7 +30,7 @@ export default async function publishTask(endpointType: EndpointType) {
   const taskReports = await TaskReport.createTaskReportsFromFiles(endpoint, serverVersion);
 
   const analyses = await Promise.all(
-    taskReports.map((taskReport) => getReportForTask(taskReport, metrics, endpoint, timeoutSec))
+    taskReports.map((taskReport) => getReportForTask(taskReport, metrics, endpoint, timeoutSec)),
   );
 
   if (globalQualityGateStatus === "") {
@@ -58,7 +58,7 @@ export async function getReportForTask(
   taskReport: TaskReport,
   metrics: Metrics,
   endpoint: Endpoint,
-  timeoutSec: number
+  timeoutSec: number,
 ): Promise<string> {
   try {
     const task = await Task.waitForTaskCompletion(endpoint, taskReport.ceTaskId, timeoutSec);
@@ -79,7 +79,7 @@ export async function getReportForTask(
   } catch (e) {
     if (e instanceof TimeOutReachedError) {
       tl.warning(
-        `Task '${taskReport.ceTaskId}' takes too long to complete. Stopping after ${timeoutSec}s of polling. No quality gate will be displayed on build result.`
+        `Task '${taskReport.ceTaskId}' takes too long to complete. Stopping after ${timeoutSec}s of polling. No quality gate will be displayed on build result.`,
       );
     } else {
       throw e;

--- a/common/ts/sonarqube/Analysis.ts
+++ b/common/ts/sonarqube/Analysis.ts
@@ -1,8 +1,8 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Endpoint, { EndpointType } from "./Endpoint";
-import Metrics from "./Metrics";
 import { formatMeasure } from "../helpers/measures";
 import { get } from "../helpers/request";
+import Endpoint, { EndpointType } from "./Endpoint";
+import Metrics from "./Metrics";
 
 interface IAnalysis {
   status: string;
@@ -26,7 +26,7 @@ export default class Analysis {
     private readonly warnings: string[],
     private readonly dashboardUrl?: string,
     private readonly metrics?: Metrics,
-    private readonly projectName?: string
+    private readonly projectName?: string,
   ) {}
 
   public get status() {
@@ -39,7 +39,7 @@ export default class Analysis {
 
   public getFailedConditions() {
     return this.conditions.filter((condition) =>
-      ["WARN", "ERROR"].includes(condition.status.toUpperCase())
+      ["WARN", "ERROR"].includes(condition.status.toUpperCase()),
     );
   }
 
@@ -91,7 +91,7 @@ export default class Analysis {
         <td style="text-align:center; color:#fff; background-color:${this.getQualityGateColor()};">
           <span style="padding:0px 4px; line-height:20px;">${formatMeasure(
             condition.actualValue,
-            metric.type
+            metric.type,
           )}</span>
         </td>
         <td>
@@ -125,7 +125,7 @@ export default class Analysis {
   public getWarnings() {
     if (this.warnings.some((w) => w.includes("Please update to at least Java 11"))) {
       return `<br><span>&#9888;</span><b>${this.warnings.find((w) =>
-        w.includes("Please update to at least Java 11")
+        w.includes("Please update to at least Java 11"),
       )}</b>`;
     } else {
       return "";
@@ -173,7 +173,7 @@ export default class Analysis {
           tl.error(`[SQ] Error retrieving analysis: ${JSON.stringify(err)}`);
         }
         throw new Error(`[SQ] Could not fetch analysis for ID '${analysisId}'`);
-      }
+      },
     );
   }
 }

--- a/common/ts/sonarqube/Endpoint.ts
+++ b/common/ts/sonarqube/Endpoint.ts
@@ -15,7 +15,10 @@ export interface EndpointData {
 }
 
 export default class Endpoint {
-  constructor(public type: EndpointType, private readonly data: EndpointData) {}
+  constructor(
+    public type: EndpointType,
+    private readonly data: EndpointData,
+  ) {}
 
   public get auth() {
     if (!this.data.token && this.data.password && this.data.password.length > 0) {
@@ -51,7 +54,7 @@ export default class Endpoint {
     const token = tl.getEndpointAuthorizationParameter(
       id,
       "apitoken",
-      type !== EndpointType.SonarCloud
+      type !== EndpointType.SonarCloud,
     );
     const username = tl.getEndpointAuthorizationParameter(id, "username", true);
     const password = tl.getEndpointAuthorizationParameter(id, "password", true);

--- a/common/ts/sonarqube/Metrics.ts
+++ b/common/ts/sonarqube/Metrics.ts
@@ -1,6 +1,6 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Endpoint from "./Endpoint";
 import { get } from "../helpers/request";
+import Endpoint from "./Endpoint";
 
 interface IMetric {
   custom?: boolean;
@@ -42,7 +42,7 @@ export default class Metrics {
 
     function inner(
       data: { f?: string; p?: number; ps?: number } = { f: "name", ps: 500 },
-      prev?: MetricsResponse
+      prev?: MetricsResponse,
     ): Promise<Metrics> {
       return get(endpoint, "/api/metrics/search", data).then((r: MetricsResponse) => {
         const result = prev ? prev.metrics.concat(r.metrics) : r.metrics;

--- a/common/ts/sonarqube/Scanner.ts
+++ b/common/ts/sonarqube/Scanner.ts
@@ -1,6 +1,6 @@
-import * as path from "path";
-import * as fs from "fs-extra";
 import * as tl from "azure-pipelines-task-lib/task";
+import * as fs from "fs-extra";
+import * as path from "path";
 import { PROP_NAMES, isWindows } from "../helpers/utils";
 
 export enum ScannerMode {
@@ -10,7 +10,10 @@ export enum ScannerMode {
 }
 
 export default class Scanner {
-  constructor(public rootPath: string, public mode: ScannerMode) {}
+  constructor(
+    public rootPath: string,
+    public mode: ScannerMode,
+  ) {}
 
   //MMF-2035
   private static isSonarCloud: boolean;
@@ -54,7 +57,7 @@ export default class Scanner {
       case ScannerMode.Other:
         tl.warning(
           `[SQ] When using Maven or Gradle, don't use the analyze task but instead tick the ` +
-            `'SonarQube' option in the Maven/Gradle task to run the scanner as part of the build.`
+            `'SonarQube' option in the Maven/Gradle task to run the scanner as part of the build.`,
         );
         return Scanner.getScanner(rootPath);
       case ScannerMode.MSBuild:
@@ -109,7 +112,11 @@ interface ScannerCLIData {
 }
 
 export class ScannerCLI extends Scanner {
-  constructor(rootPath: string, private readonly data: ScannerCLIData, private cliMode?: string) {
+  constructor(
+    rootPath: string,
+    private readonly data: ScannerCLIData,
+    private cliMode?: string,
+  ) {
     super(rootPath, ScannerMode.CLI);
   }
 
@@ -155,7 +162,7 @@ export class ScannerCLI extends Scanner {
         projectVersion: tl.getInput("cliProjectVersion"),
         projectSources: tl.getInput("cliSources"),
       },
-      mode
+      mode,
     );
   }
 }
@@ -168,7 +175,10 @@ interface ScannerMSData {
 }
 
 export class ScannerMSBuild extends Scanner {
-  constructor(rootPath: string, private readonly data: ScannerMSData) {
+  constructor(
+    rootPath: string,
+    private readonly data: ScannerMSData,
+  ) {
     super(rootPath, ScannerMode.MSBuild);
   }
 
@@ -213,7 +223,7 @@ export class ScannerMSBuild extends Scanner {
   private async makeShellScriptExecutable(scannerExecutablePath: string) {
     const scannerCliShellScripts = tl.findMatch(
       scannerExecutablePath,
-      path.join(path.dirname(scannerExecutablePath), "sonar-scanner-*", "bin", "sonar-scanner")
+      path.join(path.dirname(scannerExecutablePath), "sonar-scanner-*", "bin", "sonar-scanner"),
     )[0];
     await fs.chmod(scannerCliShellScripts, "777");
   }

--- a/common/ts/sonarqube/Task.ts
+++ b/common/ts/sonarqube/Task.ts
@@ -36,7 +36,7 @@ export default class Task {
     endpoint: Endpoint,
     taskId: string,
     tries: number,
-    delay = 1000
+    delay = 1000,
   ): Promise<Task> {
     tl.debug(`[SQ] Waiting for task '${taskId}' to complete.`);
     let query = {};
@@ -64,7 +64,7 @@ export default class Task {
               setTimeout(() => {
                 Task.waitForTaskCompletion(endpoint, taskId, tries, delay).then(resolve, reject);
                 tries--;
-              }, delay)
+              }, delay),
             );
         }
       },
@@ -75,7 +75,7 @@ export default class Task {
           tl.error(JSON.stringify(err));
         }
         throw new Error(`[SQ] Could not fetch task for ID '${taskId}'`);
-      }
+      },
     );
   }
 }

--- a/common/ts/sonarqube/TaskReport.ts
+++ b/common/ts/sonarqube/TaskReport.ts
@@ -1,6 +1,6 @@
-import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from "fs-extra";
+import * as path from "path";
 import * as semver from "semver";
 import { findMatch } from "../helpers/temp-find-method";
 import Endpoint, { EndpointType } from "./Endpoint";
@@ -49,7 +49,7 @@ export default class TaskReport {
 
     if (endpoint.type === EndpointType.SonarQube && serverVersion < semver.parse("7.2.0")) {
       tl.debug(
-        "SonarQube version < 7.2.0 detected, falling back to default location(s) for report-task.txt file."
+        "SonarQube version < 7.2.0 detected, falling back to default location(s) for report-task.txt file.",
       );
       taskReportGlob = path.join("**", REPORT_TASK_NAME);
       taskReportGlobResult = findMatch(tl.getVariable("Agent.BuildDirectory"), taskReportGlob);
@@ -58,7 +58,7 @@ export default class TaskReport {
         SONAR_TEMP_DIRECTORY_NAME,
         tl.getVariable("Build.BuildNumber"),
         "**",
-        REPORT_TASK_NAME
+        REPORT_TASK_NAME,
       );
       taskReportGlobResult = findMatch(tl.getVariable("Agent.TempDirectory"), taskReportGlob);
     }
@@ -70,7 +70,7 @@ export default class TaskReport {
   public static createTaskReportsFromFiles(
     endpoint: Endpoint,
     serverVersion: semver.SemVer,
-    filePaths = TaskReport.findTaskFileReport(endpoint, serverVersion)
+    filePaths = TaskReport.findTaskFileReport(endpoint, serverVersion),
   ): Promise<TaskReport[]> {
     return Promise.all(
       filePaths.map((filePath) => {
@@ -78,8 +78,8 @@ export default class TaskReport {
           return Promise.reject(
             TaskReport.throwInvalidReport(
               `[SQ] Could not find '${REPORT_TASK_NAME}'.` +
-                ` Possible cause: the analysis did not complete successfully.`
-            )
+                ` Possible cause: the analysis did not complete successfully.`,
+            ),
           );
         }
         tl.debug(`[SQ] Read Task report file: ${filePath}`);
@@ -87,9 +87,9 @@ export default class TaskReport {
           () => this.parseReportFile(filePath),
           () => {
             throw TaskReport.throwInvalidReport(`[SQ] Task report not found at: ${filePath}`);
-          }
+          },
         );
-      })
+      }),
     );
   }
 
@@ -121,9 +121,9 @@ export default class TaskReport {
       },
       (err) => {
         throw TaskReport.throwInvalidReport(
-          `[SQ] Error reading file: ${err.message || JSON.stringify(err)}`
+          `[SQ] Error reading file: ${err.message || JSON.stringify(err)}`,
         );
-      }
+      },
     );
   }
 
@@ -146,7 +146,7 @@ export default class TaskReport {
   private static throwInvalidReport(debugMsg: string): Error {
     tl.error(debugMsg);
     return new Error(
-      "Invalid or missing task report. Check that the analysis finished successfully."
+      "Invalid or missing task report. Check that the analysis finished successfully.",
     );
   }
 }

--- a/common/ts/sonarqube/__tests__/Analysis-test.ts
+++ b/common/ts/sonarqube/__tests__/Analysis-test.ts
@@ -1,7 +1,7 @@
-import Analysis from "../Analysis";
 import { get } from "../../helpers/request";
-import Metrics from "../Metrics";
+import Analysis from "../Analysis";
 import Endpoint, { EndpointType } from "../Endpoint";
+import Metrics from "../Metrics";
 
 jest.mock("../../helpers/request", () => ({
   get: jest.fn(() =>
@@ -18,7 +18,7 @@ jest.mock("../../helpers/request", () => ({
           },
         ],
       },
-    })
+    }),
   ),
 }));
 
@@ -53,7 +53,7 @@ it("should generate an analysis status with error", async () => {
 
 it("should generate a green analysis status", async () => {
   (get as jest.Mock<any>).mockImplementationOnce(() =>
-    Promise.resolve({ projectStatus: { status: "SUCCESS", conditions: [] } })
+    Promise.resolve({ projectStatus: { status: "SUCCESS", conditions: [] } }),
   );
 
   const analysis = await Analysis.getAnalysis(GET_ANALYSIS_DATA);
@@ -95,6 +95,6 @@ it("should display Java 11 warning", async () => {
     ],
   });
   expect(analysis.getWarnings()).toStrictEqual(
-    "<br><span>&#9888;</span><b>The version of Java (1.8.0_221) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.</b>"
+    "<br><span>&#9888;</span><b>The version of Java (1.8.0_221) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.</b>",
   );
 });

--- a/common/ts/sonarqube/__tests__/Endpoint-test.ts
+++ b/common/ts/sonarqube/__tests__/Endpoint-test.ts
@@ -1,6 +1,6 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Endpoint, { EndpointType } from "../Endpoint";
 import { PROP_NAMES } from "../../helpers/utils";
+import Endpoint, { EndpointType } from "../Endpoint";
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/common/ts/sonarqube/__tests__/TaskReport-test.ts
+++ b/common/ts/sonarqube/__tests__/TaskReport-test.ts
@@ -1,11 +1,11 @@
-import * as path from "path";
-import { writeFileSync } from "fs";
-import { fileSync } from "tmp"; // eslint-disable-line import/no-extraneous-dependencies
 import * as tl from "azure-pipelines-task-lib/task";
+import { writeFileSync } from "fs";
+import * as path from "path";
 import * as semver from "semver";
-import TaskReport from "../TaskReport";
-import Endpoint, { EndpointType } from "../Endpoint";
+import { fileSync } from "tmp"; // eslint-disable-line import/no-extraneous-dependencies
 import * as tempFindMethods from "../../helpers/temp-find-method";
+import Endpoint, { EndpointType } from "../Endpoint";
+import TaskReport from "../TaskReport";
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -21,7 +21,7 @@ ceTaskId=12345
 serverUrl=http://sonar`,
     {
       encoding: "utf-8",
-    }
+    },
   );
 
   const endpoint = new Endpoint(EndpointType.SonarCloud, null);
@@ -29,7 +29,7 @@ serverUrl=http://sonar`,
   const reports = await TaskReport.createTaskReportsFromFiles(
     endpoint,
     new semver.SemVer("7.2.0"),
-    [tmpReport.name]
+    [tmpReport.name],
   );
 
   expect(reports).toHaveLength(1);
@@ -49,7 +49,7 @@ ceTaskId=12345
 serverUrl=http://sonar`,
     {
       encoding: "utf-8",
-    }
+    },
   );
 
   const tmpReport2 = fileSync();
@@ -61,7 +61,7 @@ ceTaskId=12345
 serverUrl=http://sonar`,
     {
       encoding: "utf-8",
-    }
+    },
   );
 
   const endpoint = new Endpoint(EndpointType.SonarCloud, null);
@@ -69,7 +69,7 @@ serverUrl=http://sonar`,
   const reports = await TaskReport.createTaskReportsFromFiles(
     endpoint,
     new semver.SemVer("7.2.0"),
-    [tmpReport.name, tmpReport2.name]
+    [tmpReport.name, tmpReport2.name],
   );
 
   expect(reports).toHaveLength(2);
@@ -102,12 +102,12 @@ it("should find report files for SonarCloud", async () => {
     "sonar",
     tl.getVariable("Build.BuildNumber"),
     "**",
-    "report-task.txt"
+    "report-task.txt",
   );
   expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
   expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
     "mock root search path",
-    expectedSearchPath
+    expectedSearchPath,
   );
 });
 
@@ -133,12 +133,12 @@ it("should find report files for SonarQube above 7.2.0", async () => {
     "sonar",
     tl.getVariable("Build.BuildNumber"),
     "**",
-    "report-task.txt"
+    "report-task.txt",
   );
   expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
   expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
     "mock root search path",
-    expectedSearchPath
+    expectedSearchPath,
   );
 });
 
@@ -165,6 +165,6 @@ it("should find report files for SonarQube below 7.2.0", async () => {
   expect(tempFindMethods.findMatch).toHaveBeenCalledTimes(1);
   expect(tempFindMethods.findMatch).toHaveBeenCalledWith(
     "mock root search path",
-    expectedSearchPath
+    expectedSearchPath,
   );
 });

--- a/commonv5/ts/__tests__/analyze-task-test.ts
+++ b/commonv5/ts/__tests__/analyze-task-test.ts
@@ -6,7 +6,7 @@ it("should not have SONARQUBE_SCANNER_MODE property filled", async () => {
   jest.spyOn(tl, "getVariable").mockImplementation(() => undefined);
 
   const expectedError = new Error(
-    "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task"
+    "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task",
   );
   try {
     await analyze.default(__dirname, "JAVA_HOME");
@@ -38,7 +38,7 @@ it("should run scanner", async () => {
   jest
     .spyOn(tl, "getVariable")
     .mockReturnValueOnce(
-      '{"type":"SonarQube","data":{"url":"https://sonarqube.com/","username":"token"}}'
+      '{"type":"SonarQube","data":{"url":"https://sonarqube.com/","username":"token"}}',
     );
 
   jest.spyOn(scanner, "runAnalysis").mockImplementation(() => null);

--- a/commonv5/ts/__tests__/prepare-task-test.ts
+++ b/commonv5/ts/__tests__/prepare-task-test.ts
@@ -1,6 +1,6 @@
-import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import { Guid } from "guid-typescript";
+import * as path from "path";
 import { SemVer } from "semver";
 import * as request from "../helpers/request";
 import * as prept from "../prepare-task";
@@ -32,7 +32,7 @@ it("should display warning for dedicated extension for Sonarcloud", async () => 
   await prept.default(SQ_ENDPOINT, __dirname);
 
   expect(tl.warning).toHaveBeenCalledWith(
-    "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud"
+    "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud",
   );
 });
 
@@ -51,13 +51,13 @@ describe("branchFeatureSupported", () => {
       endpoint: Endpoint,
       product: string,
       version: string,
-      expectedBranchSupported: Boolean
+      expectedBranchSupported: Boolean,
     ) => {
       tl.debug(`${product} ${version}`);
       jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer(version));
       const actual = await prept.branchFeatureSupported(endpoint, version);
       expect(actual).toBe(expectedBranchSupported);
-    }
+    },
   );
 });
 
@@ -75,7 +75,7 @@ it("should build report task path from variables", () => {
     sonarSubDirectory,
     buildId,
     guid.toString(),
-    "report-task.txt"
+    "report-task.txt",
   );
 
   jest.spyOn(tl, "getVariable").mockImplementationOnce(() => reportDirectory);

--- a/commonv5/ts/__tests__/publish-task-test.ts
+++ b/commonv5/ts/__tests__/publish-task-test.ts
@@ -1,15 +1,15 @@
-import * as tl from "azure-pipelines-task-lib/task";
 import { InvalidApiResourceVersionError } from "azure-devops-node-api/VsoClient";
+import * as tl from "azure-pipelines-task-lib/task";
 import { SemVer } from "semver";
+import * as apiUtils from "../helpers/azdo-api-utils";
+import * as serverUtils from "../helpers/azdo-server-utils";
+import * as request from "../helpers/request";
+import * as publishTask from "../publish-task";
 import Analysis from "../sonarqube/Analysis";
 import Endpoint, { EndpointType } from "../sonarqube/Endpoint";
 import Metrics from "../sonarqube/Metrics";
 import Task, { TimeOutReachedError } from "../sonarqube/Task";
 import TaskReport from "../sonarqube/TaskReport";
-import * as publishTask from "../publish-task";
-import * as serverUtils from "../helpers/azdo-server-utils";
-import * as apiUtils from "../helpers/azdo-api-utils";
-import * as request from "../helpers/request";
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -36,7 +36,7 @@ it("should fail unless SONARQUBE_SCANNER_PARAMS are supplied", async () => {
   expect(tl.getVariable).toBeCalledWith("SONARQUBE_SCANNER_PARAMS");
   expect(tl.setResult).toBeCalledWith(
     tl.TaskResult.Failed,
-    "The SonarCloud Prepare Analysis Configuration must be added."
+    "The SonarCloud Prepare Analysis Configuration must be added.",
   );
 });
 
@@ -73,7 +73,7 @@ it("check multiple report status and set global quality gate for build propertie
     [],
     "",
     null,
-    null
+    null,
   );
 
   jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("7.2.0"));
@@ -140,7 +140,7 @@ it("check multiple report status and set global quality gate for build propertie
     [],
     "",
     null,
-    null
+    null,
   );
 
   const returnedAnalysisError = new Analysis(
@@ -149,7 +149,7 @@ it("check multiple report status and set global quality gate for build propertie
     [],
     "",
     null,
-    null
+    null,
   );
   jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("7.2.0"));
 
@@ -194,7 +194,7 @@ it("get report string should return undefined if ceTask times out", async () => 
   expect(result).toBeUndefined();
   expect(Task.waitForTaskCompletion).toHaveBeenCalledWith(SQ_ENDPOINT, TASK_REPORT.ceTaskId, 999);
   expect(tl.warning).toBeCalledWith(
-    "Task '111' takes too long to complete. Stopping after 999s of polling. No quality gate will be displayed on build result."
+    "Task '111' takes too long to complete. Stopping after 999s of polling. No quality gate will be displayed on build result.",
   );
   expect(Analysis.getAnalysis).not.toBeCalled();
 });
@@ -233,7 +233,7 @@ it("get report string for single report", async () => {
     [],
     "",
     null,
-    null
+    null,
   );
   jest.spyOn(Analysis, "getAnalysis").mockResolvedValue(returnedAnalysis);
   jest.spyOn(returnedAnalysis, "getHtmlAnalysisReport").mockImplementation(() => "dummy html");
@@ -305,7 +305,7 @@ it("task should not fail the task even if all ceTasks timeout", async () => {
     () =>
       new Promise((resolve) => {
         return resolve();
-      })
+      }),
   );
 
   await publishTask.default(EndpointType.SonarCloud);
@@ -317,9 +317,9 @@ it("task should not fail the task even if all ceTasks timeout", async () => {
   expect(serverUtils.publishBuildSummary).toBeCalledWith("\r\n", EndpointType.SonarCloud);
 
   expect(tl.warning).toBeCalledWith(
-    "Task '111' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result."
+    "Task '111' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result.",
   );
   expect(tl.warning).toBeCalledWith(
-    "Task '222' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result."
+    "Task '222' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result.",
   );
 });

--- a/commonv5/ts/analyze-task.ts
+++ b/commonv5/ts/analyze-task.ts
@@ -6,12 +6,12 @@ import Scanner, { ScannerMode } from "./sonarqube/Scanner";
 export default async function analyzeTask(
   rootPath: string,
   jdkVersionSource: string,
-  isSonarCloud: boolean = false
+  isSonarCloud: boolean = false,
 ) {
   const scannerMode: ScannerMode = ScannerMode[tl.getVariable("SONARQUBE_SCANNER_MODE")];
   if (!scannerMode) {
     throw new Error(
-      "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task"
+      "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task",
     );
   }
   Scanner.setIsSonarCloud(isSonarCloud);

--- a/commonv5/ts/helpers/__tests__/azdo-api-utils-test.ts
+++ b/commonv5/ts/helpers/__tests__/azdo-api-utils-test.ts
@@ -35,7 +35,7 @@ it("should parse extra properties correctly", () => {
 # Put one key=value per line, example:
 # sonar.exclusions=**/*.bin
 sonar.scanner.metadataFilePath=/tmp/report-task-debug.txt
-sonar.scanner.metadataFilePath=/tmp/report-task-debug-override.txt`.split("\n")
+sonar.scanner.metadataFilePath=/tmp/report-task-debug-override.txt`.split("\n"),
   ); //extraProperties
   const props = azdoApiUtils.parseScannerExtraProperties();
 

--- a/commonv5/ts/helpers/__tests__/utils-test.ts
+++ b/commonv5/ts/helpers/__tests__/utils-test.ts
@@ -13,8 +13,8 @@ describe("sanitizeVariable", () => {
   it("should sanitize username and pass", () => {
     expect(
       sanitizeVariable(
-        '{ "foo": "a", "bar": "b", "sonar.login": "aaabbbccc", "sonar.password": "fffjjjkkk" }'
-      )
+        '{ "foo": "a", "bar": "b", "sonar.login": "aaabbbccc", "sonar.password": "fffjjjkkk" }',
+      ),
     ).toBe('{"foo":"a","bar":"b"}');
   });
 });

--- a/commonv5/ts/helpers/azdo-api-utils.ts
+++ b/commonv5/ts/helpers/azdo-api-utils.ts
@@ -1,10 +1,10 @@
-import * as tl from "azure-pipelines-task-lib/task";
 import * as vm from "azure-devops-node-api";
 import {
   JsonPatchDocument,
   JsonPatchOperation,
   Operation,
 } from "azure-devops-node-api/interfaces/common/VSSInterfaces";
+import * as tl from "azure-pipelines-task-lib/task";
 
 export interface IPropertyBag {
   propertyName: string;
@@ -41,7 +41,7 @@ export async function addBuildProperty(properties: IPropertyBag[]) {
   } catch (exception) {
     tl.warning(
       "Failed to create a build property. Not blocking unless you are using the Sonar Pre-Deployment gate in Release Pipelines. Exception : " +
-        exception
+        exception,
     );
   }
 }

--- a/commonv5/ts/helpers/azdo-server-utils.ts
+++ b/commonv5/ts/helpers/azdo-server-utils.ts
@@ -1,6 +1,6 @@
-import * as path from "path";
-import * as fs from "fs-extra";
 import * as tl from "azure-pipelines-task-lib/task";
+import * as fs from "fs-extra";
+import * as path from "path";
 import * as azdoApiUtils from "./../helpers/azdo-api-utils";
 
 export function publishBuildSummary(summary: string, endpointType = "SonarQube") {
@@ -28,7 +28,7 @@ export function uploadBuildSummary(summaryPath: string, title: string): void {
       type: "Distributedtask.Core.Summary",
       name: title,
     },
-    summaryPath
+    summaryPath,
   );
 }
 

--- a/commonv5/ts/helpers/java-version-resolver.ts
+++ b/commonv5/ts/helpers/java-version-resolver.ts
@@ -9,7 +9,7 @@ export default class JavaVersionResolver {
     const javaPath = tl.getVariable(jdkversionSource);
     if (javaPath) {
       tl.debug(
-        `${jdkversionSource} was found with value ${javaPath}, will switch to it for Sonar scanner...`
+        `${jdkversionSource} was found with value ${javaPath}, will switch to it for Sonar scanner...`,
       );
       return javaPath;
     } else {
@@ -29,7 +29,7 @@ export default class JavaVersionResolver {
       }
     } else {
       tl.debug(
-        `JAVA_HOME was specified in the Run Code Analysis task configuration, nothing to do.`
+        `JAVA_HOME was specified in the Run Code Analysis task configuration, nothing to do.`,
       );
     }
   }

--- a/commonv5/ts/helpers/measures.ts
+++ b/commonv5/ts/helpers/measures.ts
@@ -7,7 +7,7 @@ interface Formatter {
 export function formatMeasure(
   value: string | number | undefined,
   type: string,
-  options?: any
+  options?: any,
 ): string {
   const formatter = getFormatter(type);
   return useFormatter(value, formatter, options);
@@ -16,7 +16,7 @@ export function formatMeasure(
 function useFormatter(
   value: string | number | undefined,
   formatter: Formatter,
-  options?: any
+  options?: any,
 ): string {
   return value !== undefined && value !== "" ? formatter(value, options) : "";
 }
@@ -40,7 +40,7 @@ function getFormatter(type: string): Formatter {
 function numberFormatter(
   value: number,
   minimumFractionDigits = 0,
-  maximumFractionDigits = minimumFractionDigits
+  maximumFractionDigits = minimumFractionDigits,
 ) {
   const { format } = new Intl.NumberFormat("en-US", {
     minimumFractionDigits,
@@ -172,7 +172,7 @@ function formatDurationShort(
   isNegative: boolean,
   days: number,
   hours: number,
-  minutes: number
+  minutes: number,
 ): string {
   if (shouldDisplayDaysInShortFormat(days)) {
     const roundedDays = Math.round(days);
@@ -184,7 +184,7 @@ function formatDurationShort(
     const roundedHours = Math.round(hours);
     const formattedHours = formatMeasure(
       isNegative ? -1 * roundedHours : roundedHours,
-      "SHORT_INT"
+      "SHORT_INT",
     );
     return formattedHours + "h";
   }

--- a/commonv5/ts/helpers/request.ts
+++ b/commonv5/ts/helpers/request.ts
@@ -30,20 +30,22 @@ function get(endpoint: Endpoint, path: string, isJson: boolean, query?: RequestD
         if (error) {
           return logAndReject(
             reject,
-            `[SQ] API GET '${path}' failed, error was: ${JSON.stringify(error)}`
+            `[SQ] API GET '${path}' failed, error was: ${JSON.stringify(error)}`,
           );
         }
         tl.debug(
-          `Response: ${response.statusCode} Body: "${isString(body) ? body : JSON.stringify(body)}"`
+          `Response: ${response.statusCode} Body: "${
+            isString(body) ? body : JSON.stringify(body)
+          }"`,
         );
         if (response.statusCode < 200 || response.statusCode >= 300) {
           return logAndReject(
             reject,
-            `[SQ] API GET '${path}' failed, status code was: ${response.statusCode}`
+            `[SQ] API GET '${path}' failed, status code was: ${response.statusCode}`,
           );
         }
         return resolve(body || (isJson ? {} : ""));
-      }
+      },
     );
   });
 }

--- a/commonv5/ts/helpers/utils.ts
+++ b/commonv5/ts/helpers/utils.ts
@@ -16,7 +16,7 @@ export const PROP_NAMES = {
 export function toCleanJSON(props: { [key: string]: string | undefined }) {
   return JSON.stringify(
     props,
-    Object.keys(props).filter((key) => props[key] != null)
+    Object.keys(props).filter((key) => props[key] != null),
   );
 }
 

--- a/commonv5/ts/prepare-task.ts
+++ b/commonv5/ts/prepare-task.ts
@@ -16,7 +16,7 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
       endpoint.url.startsWith("https://sonarqube.com"))
   ) {
     tl.warning(
-      "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud"
+      "There is a dedicated extension for SonarCloud: https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud",
     );
   }
 
@@ -31,7 +31,7 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
     /* branchFeatureSupported method magically checks everything we need for the support of the below property, 
     so we keep it like that for now, waiting for a hardening that will refactor this (at least by renaming the method name) */
     tl.debug(
-      "SonarCloud or SonarQube version >= 7.2.0 detected, setting report-task.txt file to its newest location."
+      "SonarCloud or SonarQube version >= 7.2.0 detected, setting report-task.txt file to its newest location.",
     );
     props["sonar.scanner.metadataFilePath"] = TaskReport.getDefaultPath();
     tl.debug(`[SQ] Branch and PR parameters: ${JSON.stringify(props)}`);
@@ -81,7 +81,7 @@ export async function populateBranchAndPrProps(props: { [key: string]: string })
     props["sonar.pullrequest.key"] = prId;
     props["sonar.pullrequest.base"] = branchName(tl.getVariable("System.PullRequest.TargetBranch"));
     props["sonar.pullrequest.branch"] = branchName(
-      tl.getVariable("System.PullRequest.SourceBranch")
+      tl.getVariable("System.PullRequest.SourceBranch"),
     );
     if (provider === "TfsGit") {
       props["sonar.pullrequest.provider"] = "vsts";
@@ -141,7 +141,7 @@ export async function getDefaultBranch(collectionUrl: string) {
     const gitApi = await vsts.getGitApi();
     const repo = await gitApi.getRepository(
       tl.getVariable(REPO_NAME_VAR),
-      tl.getVariable("System.TeamProject")
+      tl.getVariable("System.TeamProject"),
     );
     tl.debug(`Default branch of this repository is '${repo.defaultBranch}'`);
     return repo.defaultBranch;

--- a/commonv5/ts/publish-task.ts
+++ b/commonv5/ts/publish-task.ts
@@ -1,11 +1,11 @@
 import * as tl from "azure-pipelines-task-lib/task";
+import { fillBuildProperty, publishBuildSummary } from "./helpers/azdo-server-utils";
+import { getServerVersion } from "./helpers/request";
 import Analysis from "./sonarqube/Analysis";
-import Endpoint, { EndpointType, EndpointData } from "./sonarqube/Endpoint";
+import Endpoint, { EndpointData, EndpointType } from "./sonarqube/Endpoint";
 import Metrics from "./sonarqube/Metrics";
 import Task, { TimeOutReachedError } from "./sonarqube/Task";
 import TaskReport from "./sonarqube/TaskReport";
-import { publishBuildSummary, fillBuildProperty } from "./helpers/azdo-server-utils";
-import { getServerVersion } from "./helpers/request";
 
 let globalQualityGateStatus = "";
 
@@ -14,13 +14,13 @@ export default async function publishTask(endpointType: EndpointType) {
   if (!params) {
     tl.setResult(
       tl.TaskResult.Failed,
-      `The ${endpointType} Prepare Analysis Configuration must be added.`
+      `The ${endpointType} Prepare Analysis Configuration must be added.`,
     );
     return;
   }
 
   const endpointData: { type: EndpointType; data: EndpointData } = JSON.parse(
-    tl.getVariable("SONARQUBE_ENDPOINT")
+    tl.getVariable("SONARQUBE_ENDPOINT"),
   );
   const endpoint = new Endpoint(endpointData.type, endpointData.data);
   const metrics = await Metrics.getAllMetrics(endpoint);
@@ -30,7 +30,7 @@ export default async function publishTask(endpointType: EndpointType) {
   const taskReports = await TaskReport.createTaskReportsFromFiles(endpoint, serverVersion);
 
   const analyses = await Promise.all(
-    taskReports.map((taskReport) => getReportForTask(taskReport, metrics, endpoint, timeoutSec))
+    taskReports.map((taskReport) => getReportForTask(taskReport, metrics, endpoint, timeoutSec)),
   );
 
   if (globalQualityGateStatus === "") {
@@ -58,7 +58,7 @@ export async function getReportForTask(
   taskReport: TaskReport,
   metrics: Metrics,
   endpoint: Endpoint,
-  timeoutSec: number
+  timeoutSec: number,
 ): Promise<string> {
   try {
     const task = await Task.waitForTaskCompletion(endpoint, taskReport.ceTaskId, timeoutSec);
@@ -79,7 +79,7 @@ export async function getReportForTask(
   } catch (e) {
     if (e instanceof TimeOutReachedError) {
       tl.warning(
-        `Task '${taskReport.ceTaskId}' takes too long to complete. Stopping after ${timeoutSec}s of polling. No quality gate will be displayed on build result.`
+        `Task '${taskReport.ceTaskId}' takes too long to complete. Stopping after ${timeoutSec}s of polling. No quality gate will be displayed on build result.`,
       );
     } else {
       throw e;

--- a/commonv5/ts/sonarqube/Analysis.ts
+++ b/commonv5/ts/sonarqube/Analysis.ts
@@ -26,7 +26,7 @@ export default class Analysis {
     private readonly warnings: string[],
     private readonly dashboardUrl?: string,
     private readonly metrics?: Metrics,
-    private readonly projectName?: string
+    private readonly projectName?: string,
   ) {}
 
   public get status() {
@@ -39,7 +39,7 @@ export default class Analysis {
 
   public getFailedConditions() {
     return this.conditions.filter((condition) =>
-      ["WARN", "ERROR"].includes(condition.status.toUpperCase())
+      ["WARN", "ERROR"].includes(condition.status.toUpperCase()),
     );
   }
 
@@ -91,7 +91,7 @@ export default class Analysis {
         <td style="text-align:center; color:#fff; background-color:${this.getQualityGateColor()};">
           <span style="padding:0px 4px; line-height:20px;">${formatMeasure(
             condition.actualValue,
-            metric.type
+            metric.type,
           )}</span>
         </td>
         <td>
@@ -125,7 +125,7 @@ export default class Analysis {
   public getWarnings() {
     if (this.warnings.some((w) => w.includes("Please update to at least Java 11"))) {
       return `<br><span>&#9888;</span><b>${this.warnings.find((w) =>
-        w.includes("Please update to at least Java 11")
+        w.includes("Please update to at least Java 11"),
       )}</b>`;
     } else {
       return "";
@@ -173,7 +173,7 @@ export default class Analysis {
           tl.error(`[SQ] Error retrieving analysis: ${JSON.stringify(err)}`);
         }
         throw new Error(`[SQ] Could not fetch analysis for ID '${analysisId}'`);
-      }
+      },
     );
   }
 }

--- a/commonv5/ts/sonarqube/Endpoint.ts
+++ b/commonv5/ts/sonarqube/Endpoint.ts
@@ -16,7 +16,10 @@ export interface EndpointData {
 }
 
 export default class Endpoint {
-  constructor(public type: EndpointType, private readonly data: EndpointData) {}
+  constructor(
+    public type: EndpointType,
+    private readonly data: EndpointData,
+  ) {}
 
   public get auth() {
     if (!this.data.token && this.data.password && this.data.password.length > 0) {
@@ -58,7 +61,7 @@ export default class Endpoint {
     const token = tl.getEndpointAuthorizationParameter(
       id,
       "apitoken",
-      type !== EndpointType.SonarCloud
+      type !== EndpointType.SonarCloud,
     );
     const username = tl.getEndpointAuthorizationParameter(id, "username", true);
     const password = tl.getEndpointAuthorizationParameter(id, "password", true);

--- a/commonv5/ts/sonarqube/Metrics.ts
+++ b/commonv5/ts/sonarqube/Metrics.ts
@@ -42,7 +42,7 @@ export default class Metrics {
 
     function inner(
       data: { f?: string; p?: number; ps?: number } = { f: "name", ps: 500 },
-      prev?: MetricsResponse
+      prev?: MetricsResponse,
     ): Promise<Metrics> {
       return getJSON(endpoint, "/api/metrics/search", data).then((r: MetricsResponse) => {
         const result = prev ? prev.metrics.concat(r.metrics) : r.metrics;

--- a/commonv5/ts/sonarqube/Scanner.ts
+++ b/commonv5/ts/sonarqube/Scanner.ts
@@ -1,6 +1,6 @@
-import * as path from "path";
-import * as fs from "fs-extra";
 import * as tl from "azure-pipelines-task-lib/task";
+import * as fs from "fs-extra";
+import * as path from "path";
 import { PROP_NAMES, isWindows } from "../helpers/utils";
 
 export enum ScannerMode {
@@ -10,7 +10,10 @@ export enum ScannerMode {
 }
 
 export default class Scanner {
-  constructor(public rootPath: string, public mode: ScannerMode) {}
+  constructor(
+    public rootPath: string,
+    public mode: ScannerMode,
+  ) {}
 
   //MMF-2035
   private static isSonarCloud: boolean;
@@ -54,7 +57,7 @@ export default class Scanner {
       case ScannerMode.Other:
         tl.warning(
           `[SQ] When using Maven or Gradle, don't use the analyze task but instead tick the ` +
-            `'SonarQube' option in the Maven/Gradle task to run the scanner as part of the build.`
+            `'SonarQube' option in the Maven/Gradle task to run the scanner as part of the build.`,
         );
         return Scanner.getScanner(rootPath);
       case ScannerMode.MSBuild:
@@ -109,7 +112,11 @@ interface ScannerCLIData {
 }
 
 export class ScannerCLI extends Scanner {
-  constructor(rootPath: string, private readonly data: ScannerCLIData, private cliMode?: string) {
+  constructor(
+    rootPath: string,
+    private readonly data: ScannerCLIData,
+    private cliMode?: string,
+  ) {
     super(rootPath, ScannerMode.CLI);
   }
 
@@ -155,7 +162,7 @@ export class ScannerCLI extends Scanner {
         projectVersion: tl.getInput("cliProjectVersion"),
         projectSources: tl.getInput("cliSources"),
       },
-      mode
+      mode,
     );
   }
 }
@@ -168,7 +175,10 @@ interface ScannerMSData {
 }
 
 export class ScannerMSBuild extends Scanner {
-  constructor(rootPath: string, private readonly data: ScannerMSData) {
+  constructor(
+    rootPath: string,
+    private readonly data: ScannerMSData,
+  ) {
     super(rootPath, ScannerMode.MSBuild);
   }
 
@@ -213,7 +223,7 @@ export class ScannerMSBuild extends Scanner {
   private async makeShellScriptExecutable(scannerExecutablePath: string) {
     const scannerCliShellScripts = tl.findMatch(
       scannerExecutablePath,
-      path.join(path.dirname(scannerExecutablePath), "sonar-scanner-*", "bin", "sonar-scanner")
+      path.join(path.dirname(scannerExecutablePath), "sonar-scanner-*", "bin", "sonar-scanner"),
     )[0];
     await fs.chmod(scannerCliShellScripts, "777");
   }

--- a/commonv5/ts/sonarqube/Task.ts
+++ b/commonv5/ts/sonarqube/Task.ts
@@ -36,7 +36,7 @@ export default class Task {
     endpoint: Endpoint,
     taskId: string,
     tries: number,
-    delay = 1000
+    delay = 1000,
   ): Promise<Task> {
     tl.debug(`[SQ] Waiting for task '${taskId}' to complete.`);
     let query = {};
@@ -64,7 +64,7 @@ export default class Task {
               setTimeout(() => {
                 Task.waitForTaskCompletion(endpoint, taskId, tries, delay).then(resolve, reject);
                 tries--;
-              }, delay)
+              }, delay),
             );
         }
       },
@@ -75,7 +75,7 @@ export default class Task {
           tl.error(JSON.stringify(err));
         }
         throw new Error(`[SQ] Could not fetch task for ID '${taskId}'`);
-      }
+      },
     );
   }
 }

--- a/commonv5/ts/sonarqube/TaskReport.ts
+++ b/commonv5/ts/sonarqube/TaskReport.ts
@@ -1,7 +1,7 @@
-import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from "fs-extra";
 import { Guid } from "guid-typescript";
+import * as path from "path";
 import * as semver from "semver";
 import Endpoint, { EndpointType } from "./Endpoint";
 
@@ -49,14 +49,14 @@ export default class TaskReport {
       SONAR_TEMP_DIRECTORY_NAME,
       tl.getVariable("Build.BuildId"),
       "<GUID>",
-      REPORT_TASK_NAME
+      REPORT_TASK_NAME,
     );
   }
 
   public static getDefaultPath() {
     return path.join(
       tl.getVariable("Agent.TempDirectory"),
-      TaskReport.getDefaultPathTemplate().replace("<GUID>", Guid.create().toString())
+      TaskReport.getDefaultPathTemplate().replace("<GUID>", Guid.create().toString()),
     );
   }
 
@@ -70,7 +70,7 @@ export default class TaskReport {
 
     if (endpoint.type === EndpointType.SonarQube && semver.satisfies(serverVersion, "<7.2.0")) {
       tl.debug(
-        "SonarQube version < 7.2.0 detected, falling back to default location(s) for report-task.txt file."
+        "SonarQube version < 7.2.0 detected, falling back to default location(s) for report-task.txt file.",
       );
       taskReportGlob = path.join("**", REPORT_TASK_NAME);
       taskReportGlobResult = tl.findMatch(tl.getVariable("Agent.BuildDirectory"), taskReportGlob);
@@ -89,7 +89,7 @@ export default class TaskReport {
   public static createTaskReportsFromFiles(
     endpoint: Endpoint,
     serverVersion: semver.SemVer,
-    filePaths = TaskReport.findTaskFileReport(endpoint, serverVersion)
+    filePaths = TaskReport.findTaskFileReport(endpoint, serverVersion),
   ): Promise<TaskReport[]> {
     return Promise.all(
       filePaths.map((filePath) => {
@@ -97,8 +97,8 @@ export default class TaskReport {
           return Promise.reject(
             TaskReport.throwInvalidReport(
               `[SQ] Could not find '${REPORT_TASK_NAME}'.` +
-                ` Possible cause: the analysis did not complete successfully.`
-            )
+                ` Possible cause: the analysis did not complete successfully.`,
+            ),
           );
         }
         tl.debug(`[SQ] Read Task report file: ${filePath}`);
@@ -106,9 +106,9 @@ export default class TaskReport {
           () => this.parseReportFile(filePath),
           () => {
             throw TaskReport.throwInvalidReport(`[SQ] Task report not found at: ${filePath}`);
-          }
+          },
         );
-      })
+      }),
     );
   }
 
@@ -140,9 +140,9 @@ export default class TaskReport {
       },
       (err) => {
         throw TaskReport.throwInvalidReport(
-          `[SQ] Error reading file: ${err.message || JSON.stringify(err)}`
+          `[SQ] Error reading file: ${err.message || JSON.stringify(err)}`,
         );
-      }
+      },
     );
   }
 
@@ -165,7 +165,7 @@ export default class TaskReport {
   private static throwInvalidReport(debugMsg: string): Error {
     tl.error(debugMsg);
     return new Error(
-      "Invalid or missing task report. Check that the analysis finished successfully."
+      "Invalid or missing task report. Check that the analysis finished successfully.",
     );
   }
 }

--- a/commonv5/ts/sonarqube/__tests__/Analysis-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/Analysis-test.ts
@@ -18,7 +18,7 @@ jest.mock("../../helpers/request", () => ({
           },
         ],
       },
-    })
+    }),
   ),
 }));
 
@@ -53,7 +53,7 @@ it("should generate an analysis status with error", async () => {
 
 it("should generate a green analysis status", async () => {
   (getJSON as jest.Mock<any>).mockImplementationOnce(() =>
-    Promise.resolve({ projectStatus: { status: "SUCCESS", conditions: [] } })
+    Promise.resolve({ projectStatus: { status: "SUCCESS", conditions: [] } }),
   );
 
   const analysis = await Analysis.getAnalysis(GET_ANALYSIS_DATA);
@@ -95,6 +95,6 @@ it("should display Java 11 warning", async () => {
     ],
   });
   expect(analysis.getWarnings()).toStrictEqual(
-    "<br><span>&#9888;</span><b>The version of Java (1.8.0_221) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.</b>"
+    "<br><span>&#9888;</span><b>The version of Java (1.8.0_221) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.</b>",
   );
 });

--- a/commonv5/ts/sonarqube/__tests__/TaskReport-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/TaskReport-test.ts
@@ -20,7 +20,7 @@ ceTaskId=12345
 serverUrl=http://sonar`,
     {
       encoding: "utf-8",
-    }
+    },
   );
 
   const endpoint = new Endpoint(EndpointType.SonarCloud, null);
@@ -28,7 +28,7 @@ serverUrl=http://sonar`,
   const reports = await TaskReport.createTaskReportsFromFiles(
     endpoint,
     new semver.SemVer("7.2.0"),
-    [tmpReport.name]
+    [tmpReport.name],
   );
 
   expect(reports).toHaveLength(1);
@@ -48,7 +48,7 @@ ceTaskId=12345
 serverUrl=http://sonar`,
     {
       encoding: "utf-8",
-    }
+    },
   );
 
   const tmpReport2 = fileSync();
@@ -60,7 +60,7 @@ ceTaskId=12345
 serverUrl=http://sonar`,
     {
       encoding: "utf-8",
-    }
+    },
   );
 
   const endpoint = new Endpoint(EndpointType.SonarCloud, null);
@@ -68,7 +68,7 @@ serverUrl=http://sonar`,
   const reports = await TaskReport.createTaskReportsFromFiles(
     endpoint,
     new semver.SemVer("7.2.0"),
-    [tmpReport.name, tmpReport2.name]
+    [tmpReport.name, tmpReport2.name],
   );
 
   expect(reports).toHaveLength(2);

--- a/extensions/sonarcloud/tasks/prepare/v1/prepare.ts
+++ b/extensions/sonarcloud/tasks/prepare/v1/prepare.ts
@@ -1,12 +1,12 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Endpoint, { EndpointType } from "../../../../../common/ts/sonarqube/Endpoint";
 import prepareTask from "../../../../../common/ts/prepare-task";
+import Endpoint, { EndpointType } from "../../../../../common/ts/sonarqube/Endpoint";
 
 async function run() {
   try {
     const endpoint = Endpoint.getEndpoint(
       tl.getInput(EndpointType.SonarCloud, true),
-      EndpointType.SonarCloud
+      EndpointType.SonarCloud,
     );
     await prepareTask(endpoint, __dirname);
   } catch (err) {

--- a/extensions/sonarqube/tasks/prepare/v4/prepare.ts
+++ b/extensions/sonarqube/tasks/prepare/v4/prepare.ts
@@ -1,12 +1,12 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Endpoint, { EndpointType } from "../../../../../common/ts/sonarqube/Endpoint";
 import prepareTask from "../../../../../common/ts/prepare-task";
+import Endpoint, { EndpointType } from "../../../../../common/ts/sonarqube/Endpoint";
 
 async function run() {
   try {
     const endpoint = Endpoint.getEndpoint(
       tl.getInput(EndpointType.SonarQube, true),
-      EndpointType.SonarQube
+      EndpointType.SonarQube,
     );
     await prepareTask(endpoint, __dirname);
   } catch (err) {

--- a/extensions/sonarqube/tasks/prepare/v5/prepare.ts
+++ b/extensions/sonarqube/tasks/prepare/v5/prepare.ts
@@ -1,12 +1,12 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import Endpoint, { EndpointType } from "../../../../../common/ts/sonarqube/Endpoint";
 import prepareTask from "../../../../../common/ts/prepare-task";
+import Endpoint, { EndpointType } from "../../../../../common/ts/sonarqube/Endpoint";
 
 async function run() {
   try {
     const endpoint = Endpoint.getEndpoint(
       tl.getInput(EndpointType.SonarQube, true),
-      EndpointType.SonarQube
+      EndpointType.SonarQube,
     );
     await prepareTask(endpoint, __dirname);
   } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "merge-stream": "2.0.0",
         "needle": "3.2.0",
         "openpgp": "5.10.1",
-        "prettier": "2.8.8",
+        "prettier": "3.0.3",
         "request": "2.88.2",
         "semver": "5.5.0",
         "sonarqube-scanner": "3.0.0",
@@ -12693,15 +12693,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -25844,9 +25844,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "prettify-xml": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "merge-stream": "2.0.0",
     "needle": "3.2.0",
     "openpgp": "5.10.1",
-    "prettier": "2.8.8",
+    "prettier": "3.0.3",
     "request": "2.88.2",
     "semver": "5.5.0",
     "sonarqube-scanner": "3.0.0",
@@ -105,10 +105,6 @@
     "transform": {
       ".(ts)$": "ts-jest"
     }
-  },
-  "prettier": {
-    "printWidth": 100,
-    "singleQuote": false
   },
   "dependencies": {
     "azure-pipelines-task-lib": "4.4.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "./common/ts/**/*.ts",
+    "./commonv5/ts/**/*.ts",
     "./extensions/**/*.ts"
   ]
 }


### PR DESCRIPTION
Currently, we have to drop auto-formatting in the extension when we work on it. Also, there are some ESLint false positive errors.
This PR focuses on developer experience and formats all the code with `npm run format` properly