### PR TITLE
VSTS-221 Document logic to decide whether we are on the main branch or not

### DIFF
--- a/commonv5/ts/__tests__/prepare-task-test.ts
+++ b/commonv5/ts/__tests__/prepare-task-test.ts
@@ -2,6 +2,7 @@ import * as tl from "azure-pipelines-task-lib/task";
 import { Guid } from "guid-typescript";
 import * as path from "path";
 import { SemVer } from "semver";
+import { DEFAULT_BRANCH_NAME } from "../helpers/constants";
 import * as request from "../helpers/request";
 import * as prept from "../prepare-task";
 import Endpoint, { EndpointType } from "../sonarqube/Endpoint";
@@ -27,7 +28,7 @@ it("should display warning for dedicated extension for Sonarcloud", async () => 
   jest.spyOn(Scanner, "getPrepareScanner").mockImplementation(() => scannerObject);
   jest.spyOn(scannerObject, "runPrepare").mockImplementation(() => null);
   jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("7.2.0"));
-  jest.spyOn(prept, "getDefaultBranch").mockResolvedValue("refs/heads/master");
+  jest.spyOn(prept, "getDefaultBranch").mockResolvedValue(DEFAULT_BRANCH_NAME);
 
   await prept.default(SQ_ENDPOINT, __dirname);
 

--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -1,0 +1,23 @@
+export const PROP_NAMES = {
+  HOST_URL: "sonar.host.url",
+  TOKEN: "sonar.token",
+  LOGIN: "sonar.login",
+  PASSSWORD: "sonar.password",
+  ORG: "sonar.organization",
+  PROJECTKEY: "sonar.projectKey",
+  PROJECTNAME: "sonar.projectName",
+  PROJECTVERSION: "sonar.projectVersion",
+  PROJECTSOURCES: "sonar.sources",
+  PROJECTSETTINGS: "project.settings",
+};
+
+export enum AzureProvider {
+  TfsGit = "TfsGit",
+  Svn = "Svn",
+  Git = "Git",
+  GitHub = "GitHub",
+  GitHubEnterprise = "GitHubEnterprise",
+  Bitbucket = "Bitbucket",
+}
+
+export const DEFAULT_BRANCH_NAME = "refs/heads/master";

--- a/commonv5/ts/helpers/utils.ts
+++ b/commonv5/ts/helpers/utils.ts
@@ -1,17 +1,5 @@
 import * as tl from "azure-pipelines-task-lib/task";
-
-export const PROP_NAMES = {
-  HOST_URL: "sonar.host.url",
-  TOKEN: "sonar.token",
-  LOGIN: "sonar.login",
-  PASSSWORD: "sonar.password",
-  ORG: "sonar.organization",
-  PROJECTKEY: "sonar.projectKey",
-  PROJECTNAME: "sonar.projectName",
-  PROJECTVERSION: "sonar.projectVersion",
-  PROJECTSOURCES: "sonar.sources",
-  PROJECTSETTINGS: "project.settings",
-};
+import { PROP_NAMES } from "./constants";
 
 export function toCleanJSON(props: { [key: string]: string | undefined }) {
   return JSON.stringify(

--- a/commonv5/ts/prepare-task.ts
+++ b/commonv5/ts/prepare-task.ts
@@ -1,13 +1,12 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as semver from "semver";
 import { getWebApi, parseScannerExtraProperties } from "./helpers/azdo-api-utils";
+import { AzureProvider, DEFAULT_BRANCH_NAME as DEFAULT_BRANCH_REF } from "./helpers/constants";
 import { getServerVersion } from "./helpers/request";
 import { toCleanJSON } from "./helpers/utils";
 import Endpoint, { EndpointType } from "./sonarqube/Endpoint";
 import Scanner, { ScannerMode } from "./sonarqube/Scanner";
 import TaskReport from "./sonarqube/TaskReport";
-
-const REPO_NAME_VAR = "Build.Repository.Name";
 
 export default async function prepareTask(endpoint: Endpoint, rootPath: string) {
   if (
@@ -26,8 +25,8 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
 
   let props: { [key: string]: string } = {};
 
-  if (await branchFeatureSupported(endpoint, serverVersion)) {
-    await populateBranchAndPrProps(props);
+  if (branchFeatureSupported(endpoint, serverVersion)) {
+    populateBranchAndPrProps(props);
     /* branchFeatureSupported method magically checks everything we need for the support of the below property, 
     so we keep it like that for now, waiting for a hardening that will refactor this (at least by renaming the method name) */
     tl.debug(
@@ -73,80 +72,103 @@ export function branchFeatureSupported(endpoint, serverVersion: string | semver.
   return semver.satisfies(serverVersion, ">=7.2.0");
 }
 
-export async function populateBranchAndPrProps(props: { [key: string]: string }) {
+export function populateBranchAndPrProps(props: { [key: string]: string }) {
   const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-  const prId = tl.getVariable("System.PullRequest.PullRequestId");
-  const provider = tl.getVariable("Build.Repository.Provider");
-  if (prId) {
-    props["sonar.pullrequest.key"] = prId;
-    props["sonar.pullrequest.base"] = branchName(tl.getVariable("System.PullRequest.TargetBranch"));
-    props["sonar.pullrequest.branch"] = branchName(
+  const provider = tl.getVariable("Build.Repository.Provider") as AzureProvider;
+  const pullRequestId = tl.getVariable("System.PullRequest.PullRequestId");
+
+  // If analyzing a pull request
+  if (pullRequestId) {
+    props["sonar.pullrequest.key"] = pullRequestId;
+    props["sonar.pullrequest.base"] = getBranchNameFromRef(
+      tl.getVariable("System.PullRequest.TargetBranch"),
+    );
+    props["sonar.pullrequest.branch"] = getBranchNameFromRef(
       tl.getVariable("System.PullRequest.SourceBranch"),
     );
-    if (provider === "TfsGit") {
+
+    // Set provider-specific properties
+    if (provider === AzureProvider.TfsGit) {
       props["sonar.pullrequest.provider"] = "vsts";
       props["sonar.pullrequest.vsts.instanceUrl"] = collectionUrl;
       props["sonar.pullrequest.vsts.project"] = tl.getVariable("System.TeamProject");
-      props["sonar.pullrequest.vsts.repository"] = tl.getVariable(REPO_NAME_VAR);
-    } else if (provider === "GitHub" || provider === "GitHubEnterprise") {
+      props["sonar.pullrequest.vsts.repository"] = tl.getVariable("Build.Repository.Name");
+    } else if (provider === AzureProvider.GitHub || provider === AzureProvider.GitHubEnterprise) {
       props["sonar.pullrequest.key"] = tl.getVariable("System.PullRequest.PullRequestNumber");
       props["sonar.pullrequest.provider"] = "github";
-      props["sonar.pullrequest.github.repository"] = tl.getVariable(REPO_NAME_VAR);
-    } else if (provider === "Bitbucket") {
+      props["sonar.pullrequest.github.repository"] = tl.getVariable("Build.Repository.Name");
+    } else if (provider === AzureProvider.Bitbucket) {
       props["sonar.pullrequest.provider"] = "bitbucketcloud";
     } else {
       tl.warning(`Unsupported PR provider '${provider}'`);
       props["sonar.scanner.skip"] = "true";
     }
-  } else {
-    let isDefaultBranch = true;
-    const currentBranch = tl.getVariable("Build.SourceBranch");
-    if (provider === "TfsGit") {
-      isDefaultBranch = currentBranch === (await getDefaultBranch(collectionUrl));
-    } else if (provider === "Git" || provider === "GitHub" || provider === "GitHubEnterprise") {
-      // TODO for GitHub we should get the default branch configured on the repo
-      isDefaultBranch = currentBranch === "refs/heads/master";
-    } else if (provider === "Bitbucket") {
-      // TODO for Bitbucket Cloud we should get the main branch configured on the repo
-      isDefaultBranch = currentBranch === "refs/heads/master";
-    } else if (provider === "Svn") {
-      isDefaultBranch = currentBranch === "trunk";
-    }
-    if (!isDefaultBranch) {
-      // VSTS-165 don't use Build.SourceBranchName
-      props["sonar.branch.name"] = branchName(tl.getVariable("Build.SourceBranch"));
-    }
+  } else if (!isDefaultBranch()) {
+    // If analyzing a branch and not on default branch, specify branch
+    props["sonar.branch.name"] = getBranchNameFromRef(tl.getVariable("Build.SourceBranch"));
   }
 }
 
 /**
- * Waiting for https://github.com/Microsoft/vsts-tasks/issues/7591
+ * In the case of branch analysis, we need to know if we are on the default branch.
+ * If that is the case, we try to not specify the sonar.branch.name parameter to avoid getting
+ * rejected by SonarQube Communnity Edition.
  */
-function branchName(fullName: string) {
-  if (fullName.startsWith("refs/heads/")) {
-    return fullName.substring("refs/heads/".length);
+async function isDefaultBranch() {
+  const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
+  const provider = tl.getVariable("Build.Repository.Provider") as AzureProvider;
+  const currentBranch = tl.getVariable("Build.SourceBranch");
+
+  if (provider === AzureProvider.TfsGit) {
+    return currentBranch === (await getDefaultBranch(collectionUrl));
   }
-  return fullName;
+
+  if (provider === AzureProvider.Svn) {
+    return currentBranch === "trunk";
+  }
+
+  // For these providers, we can not know what is the default branch for projects.
+  // Therefore, we assume that if the branch is called master, then it is the default one.
+  // @see Feature request https://developercommunity.visualstudio.com/t/Add-a-variable-with-the-name-of-the-defa/10400800
+  if (
+    [
+      AzureProvider.Git,
+      AzureProvider.GitHub,
+      AzureProvider.GitHubEnterprise,
+      AzureProvider.Bitbucket,
+    ].includes(provider)
+  ) {
+    tl.debug(
+      `Unable to get default branch with provider ${provider}, assuming 'master' is the default branch.`,
+    );
+    return currentBranch === DEFAULT_BRANCH_REF;
+  }
+
+  return false;
 }
 
 /**
- * Waiting for https://github.com/Microsoft/vsts-tasks/issues/7592
- * query the repo to get the full name of the default branch.
- * @param collectionUrl
+ * We compute the branch name from the full ref, @see VSTS-165 Don't use Build.SourceBranchName
  */
-export async function getDefaultBranch(collectionUrl: string) {
-  const DEFAULT = "refs/heads/master";
+function getBranchNameFromRef(fullName: string) {
+  return fullName.replace(/^refs\/heads\//, "");
+}
+
+/**
+ * Query Azure Repo to get the full name of the default branch
+ */
+export async function getDefaultBranch(collectionUrl: string): Promise<string | null> {
   try {
     const vsts = getWebApi(collectionUrl);
     const gitApi = await vsts.getGitApi();
     const repo = await gitApi.getRepository(
-      tl.getVariable(REPO_NAME_VAR),
+      tl.getVariable("Build.Repository.Name"),
       tl.getVariable("System.TeamProject"),
     );
     tl.debug(`Default branch of this repository is '${repo.defaultBranch}'`);
     return repo.defaultBranch;
   } catch (e) {
     tl.debug("Unable to get default branch, defaulting to 'master': " + e);
-    return DEFAULT;
+    return DEFAULT_BRANCH_REF;
   }
 }

--- a/commonv5/ts/sonarqube/Endpoint.ts
+++ b/commonv5/ts/sonarqube/Endpoint.ts
@@ -1,6 +1,6 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as semver from "semver";
-import { PROP_NAMES } from "../helpers/utils";
+import { PROP_NAMES } from "../helpers/constants";
 
 export enum EndpointType {
   SonarCloud = "SonarCloud",

--- a/commonv5/ts/sonarqube/Scanner.ts
+++ b/commonv5/ts/sonarqube/Scanner.ts
@@ -1,7 +1,8 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { PROP_NAMES, isWindows } from "../helpers/utils";
+import { PROP_NAMES } from "../helpers/constants";
+import { isWindows } from "../helpers/utils";
 
 export enum ScannerMode {
   MSBuild = "MSBuild",

--- a/commonv5/ts/sonarqube/__tests__/Endpoint-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/Endpoint-test.ts
@@ -1,5 +1,5 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import { PROP_NAMES } from "../../helpers/utils";
+import { PROP_NAMES } from "../../helpers/constants";
 import Endpoint, { EndpointType } from "../Endpoint";
 
 beforeEach(() => {


### PR DESCRIPTION
The current behavior is:
- For azure repos, we send the property if the analyzed branch is not the default branch. If the Web API can not be reached, the fallback is to send the property only if the analyzed branch is not `master`.
- For SVN, we send the property if the analyzed branch is not `trunk`. 
- For other providers we send the property if and only if the branch is not `master`

This PR focuses on code quality and documentation to make the current behavior clear