### PR TITLE
VSTS-221 VSTS-308 Document logic to decide whether we are on the main branch or not & multistage pipeline and major task versions

### DIFF
--- a/common/ts/sonarqube/Scanner.ts
+++ b/common/ts/sonarqube/Scanner.ts
@@ -115,7 +115,7 @@ export class ScannerCLI extends Scanner {
   constructor(
     rootPath: string,
     private readonly data: ScannerCLIData,
-    private cliMode?: string,
+    private readonly cliMode?: string,
   ) {
     super(rootPath, ScannerMode.CLI);
   }

--- a/commonv5/ts/analyze-task.ts
+++ b/commonv5/ts/analyze-task.ts
@@ -2,23 +2,30 @@ import * as tl from "azure-pipelines-task-lib/task";
 import JavaVersionResolver from "./helpers/java-version-resolver";
 import { sanitizeVariable } from "./helpers/utils";
 import Scanner, { ScannerMode } from "./sonarqube/Scanner";
+import { TASK_MISSING_VARIABLE_ERROR_HINT, TaskVariables } from "./helpers/constants";
 
 export default async function analyzeTask(
   rootPath: string,
   jdkVersionSource: string,
   isSonarCloud: boolean = false,
 ) {
-  const scannerMode: ScannerMode = ScannerMode[tl.getVariable("SONARQUBE_SCANNER_MODE")];
-  if (!scannerMode) {
-    throw new Error(
-      "[SQ] The 'Prepare Analysis Configuration' task was not executed prior to this task",
+  if (typeof tl.getVariable(TaskVariables.SonarQubeScannerMode) === "undefined") {
+    tl.setResult(
+      tl.TaskResult.Failed,
+      `Variables are missing. Please make sure that you are running the Prepare task before running the Analyze task.\n${TASK_MISSING_VARIABLE_ERROR_HINT}`,
     );
+    return;
   }
+
+  const scannerMode: ScannerMode = ScannerMode[tl.getVariable(TaskVariables.SonarQubeScannerMode)];
   Scanner.setIsSonarCloud(isSonarCloud);
   JavaVersionResolver.setJavaVersion(jdkVersionSource);
   const scanner = Scanner.getAnalyzeScanner(rootPath, scannerMode);
-  const sqScannerParams = tl.getVariable("SONARQUBE_SCANNER_PARAMS");
+  const sqScannerParams = tl.getVariable(TaskVariables.SonarQubeScannerParams);
   await scanner.runAnalysis();
-  tl.setVariable("SONARQUBE_SCANNER_PARAMS", sanitizeVariable(JSON.stringify(sqScannerParams)));
+  tl.setVariable(
+    TaskVariables.SonarQubeScannerParams,
+    sanitizeVariable(JSON.stringify(sqScannerParams)),
+  );
   JavaVersionResolver.revertJavaHomeToOriginal();
 }

--- a/commonv5/ts/helpers/__tests__/java-version-resolver-test.ts
+++ b/commonv5/ts/helpers/__tests__/java-version-resolver-test.ts
@@ -1,5 +1,6 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import JavaVersionResolver from "../java-version-resolver";
+import { TaskVariables } from "../constants";
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -15,7 +16,7 @@ describe("setJavaVersion", () => {
 
     JavaVersionResolver.setJavaVersion(jdkSource);
 
-    const actualJavaHome = tl.getVariable("JAVA_HOME");
+    const actualJavaHome = tl.getVariable(TaskVariables.JavaHome);
 
     expect(actualJavaHome).toBe(expectedJavaPath);
   });
@@ -30,7 +31,7 @@ describe("setJavaVersion", () => {
 
     JavaVersionResolver.setJavaVersion(jdkSource);
 
-    const actualJavaHome = tl.getVariable("JAVA_HOME");
+    const actualJavaHome = tl.getVariable(TaskVariables.JavaHome);
 
     expect(actualJavaHome).toBe(java11Path);
   });

--- a/commonv5/ts/helpers/__tests__/utils-test.ts
+++ b/commonv5/ts/helpers/__tests__/utils-test.ts
@@ -1,4 +1,4 @@
-import { sanitizeVariable, setIfNotEmpty, toCleanJSON } from "../utils";
+import { sanitizeVariable, toCleanJSON } from "../utils";
 
 describe("toCleanJSON", () => {
   it("should jsonify", () => {
@@ -16,17 +16,5 @@ describe("sanitizeVariable", () => {
         '{ "foo": "a", "bar": "b", "sonar.login": "aaabbbccc", "sonar.password": "fffjjjkkk" }',
       ),
     ).toBe('{"foo":"a","bar":"b"}');
-  });
-});
-
-describe("setIfNotEmpty", () => {
-  it("should correctly set a property", () => {
-    const test = {};
-    setIfNotEmpty(test, "foo", "");
-    expect(test).toEqual({});
-    setIfNotEmpty(test, "foo", undefined);
-    expect(test).toEqual({});
-    setIfNotEmpty(test, "foo", "bar");
-    expect(test).toEqual({ foo: "bar" });
   });
 });

--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -25,3 +25,16 @@ export const DEFAULT_BRANCH_NAME = "refs/heads/master";
 export enum AzureBuildVariables {
   BuildRepositoryName = "Build.Repository.Name",
 }
+
+export enum TaskVariables {
+  SonarQubeServerVersion = "SONARQUBE_SERVER_VERSION",
+  SonarQubeScannerMode = "SONARQUBE_SCANNER_MODE",
+  SonarQubeScannerParams = "SONARQUBE_SCANNER_PARAMS",
+  SonarQubeScannerReportTaskFile = "SONARQUBE_SCANNER_REPORTTASKFILE",
+  SonarQubeEndpoint = "SONARQUBE_ENDPOINT",
+  SonarQubeScannerMSBuildExe = "SONARQUBE_SCANNER_MSBUILD_EXE",
+  SonarQubeScannerMSBuildDll = "SONARQUBE_SCANNER_MSBUILD_DLL",
+  JavaHome = "JAVA_HOME",
+}
+
+export const TASK_MISSING_VARIABLE_ERROR_HINT = `Make sure you are not mixing tasks from different major versions. If you are using a multistage pipeline, make sure the tasks are in the same stage.`;

--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -1,0 +1,27 @@
+export const PROP_NAMES = {
+  HOST_URL: "sonar.host.url",
+  TOKEN: "sonar.token",
+  LOGIN: "sonar.login",
+  PASSSWORD: "sonar.password",
+  ORG: "sonar.organization",
+  PROJECTKEY: "sonar.projectKey",
+  PROJECTNAME: "sonar.projectName",
+  PROJECTVERSION: "sonar.projectVersion",
+  PROJECTSOURCES: "sonar.sources",
+  PROJECTSETTINGS: "project.settings",
+};
+
+export enum AzureProvider {
+  TfsGit = "TfsGit",
+  Svn = "Svn",
+  Git = "Git",
+  GitHub = "GitHub",
+  GitHubEnterprise = "GitHubEnterprise",
+  Bitbucket = "Bitbucket",
+}
+
+export const DEFAULT_BRANCH_NAME = "refs/heads/master";
+
+export enum AzureBuildVariables {
+  BuildRepositoryName = "Build.Repository.Name",
+}

--- a/commonv5/ts/helpers/java-version-resolver.ts
+++ b/commonv5/ts/helpers/java-version-resolver.ts
@@ -1,4 +1,5 @@
 import * as tl from "azure-pipelines-task-lib/task";
+import { TaskVariables } from "./constants";
 
 export default class JavaVersionResolver {
   private static javaHomeOriginalPath: string;
@@ -23,8 +24,8 @@ export default class JavaVersionResolver {
     if (jdkversionSource !== "JAVA_HOME") {
       newJavaPath = this.lookupVariable(jdkversionSource);
       if (newJavaPath) {
-        this.javaHomeOriginalPath = tl.getVariable("JAVA_HOME");
-        tl.setVariable("JAVA_HOME", newJavaPath);
+        this.javaHomeOriginalPath = tl.getVariable(TaskVariables.JavaHome);
+        tl.setVariable(TaskVariables.JavaHome, newJavaPath);
         this.isJavaNewVersionSet = true;
       }
     } else {
@@ -37,7 +38,7 @@ export default class JavaVersionResolver {
   public static revertJavaHomeToOriginal() {
     if (this.isJavaNewVersionSet) {
       tl.debug("Reverting JAVA_HOME to its initial path.");
-      tl.setVariable("JAVA_HOME", this.javaHomeOriginalPath);
+      tl.setVariable(TaskVariables.JavaHome, this.javaHomeOriginalPath);
     }
   }
 }

--- a/commonv5/ts/helpers/utils.ts
+++ b/commonv5/ts/helpers/utils.ts
@@ -1,17 +1,5 @@
 import * as tl from "azure-pipelines-task-lib/task";
-
-export const PROP_NAMES = {
-  HOST_URL: "sonar.host.url",
-  TOKEN: "sonar.token",
-  LOGIN: "sonar.login",
-  PASSSWORD: "sonar.password",
-  ORG: "sonar.organization",
-  PROJECTKEY: "sonar.projectKey",
-  PROJECTNAME: "sonar.projectName",
-  PROJECTVERSION: "sonar.projectVersion",
-  PROJECTSOURCES: "sonar.sources",
-  PROJECTSETTINGS: "project.settings",
-};
+import { PROP_NAMES } from "./constants";
 
 export function toCleanJSON(props: { [key: string]: string | undefined }) {
   return JSON.stringify(

--- a/commonv5/ts/helpers/utils.ts
+++ b/commonv5/ts/helpers/utils.ts
@@ -8,12 +8,6 @@ export function toCleanJSON(props: { [key: string]: string | undefined }) {
   );
 }
 
-export function setIfNotEmpty(props: { [key: string]: string }, key: string, value?: string) {
-  if (value) {
-    props[key] = value;
-  }
-}
-
 export function sanitizeVariable(jsonPayload: string) {
   const jsonObj = JSON.parse(jsonPayload);
   delete jsonObj[PROP_NAMES.LOGIN];

--- a/commonv5/ts/prepare-task.ts
+++ b/commonv5/ts/prepare-task.ts
@@ -1,13 +1,16 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as semver from "semver";
 import { getWebApi, parseScannerExtraProperties } from "./helpers/azdo-api-utils";
+import {
+  AzureBuildVariables,
+  AzureProvider,
+  DEFAULT_BRANCH_NAME as DEFAULT_BRANCH_REF,
+} from "./helpers/constants";
 import { getServerVersion } from "./helpers/request";
 import { toCleanJSON } from "./helpers/utils";
 import Endpoint, { EndpointType } from "./sonarqube/Endpoint";
 import Scanner, { ScannerMode } from "./sonarqube/Scanner";
 import TaskReport from "./sonarqube/TaskReport";
-
-const REPO_NAME_VAR = "Build.Repository.Name";
 
 export default async function prepareTask(endpoint: Endpoint, rootPath: string) {
   const scannerMode: ScannerMode = ScannerMode[tl.getInput("scannerMode")];
@@ -16,8 +19,8 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
 
   let props: { [key: string]: string } = {};
 
-  if (await branchFeatureSupported(endpoint, serverVersion)) {
-    await populateBranchAndPrProps(props);
+  if (branchFeatureSupported(endpoint, serverVersion)) {
+    populateBranchAndPrProps(props);
     /* branchFeatureSupported method magically checks everything we need for the support of the below property, 
     so we keep it like that for now, waiting for a hardening that will refactor this (at least by renaming the method name) */
     tl.debug(
@@ -63,83 +66,109 @@ export function branchFeatureSupported(endpoint, serverVersion: string | semver.
   return semver.satisfies(serverVersion, ">=7.2.0");
 }
 
-export async function populateBranchAndPrProps(props: { [key: string]: string }) {
+export function populateBranchAndPrProps(props: { [key: string]: string }) {
   const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-  const prId = tl.getVariable("System.PullRequest.PullRequestId");
-  const provider = tl.getVariable("Build.Repository.Provider");
-  if (prId) {
-    props["sonar.pullrequest.key"] = prId;
-    props["sonar.pullrequest.base"] = branchName(tl.getVariable("System.PullRequest.TargetBranch"));
-    props["sonar.pullrequest.branch"] = branchName(
+  const provider = tl.getVariable("Build.Repository.Provider") as AzureProvider;
+  const pullRequestId = tl.getVariable("System.PullRequest.PullRequestId");
+
+  // If analyzing a pull request
+  if (pullRequestId) {
+    props["sonar.pullrequest.key"] = pullRequestId;
+    props["sonar.pullrequest.base"] = getBranchNameFromRef(
+      tl.getVariable("System.PullRequest.TargetBranch"),
+    );
+    props["sonar.pullrequest.branch"] = getBranchNameFromRef(
       tl.getVariable("System.PullRequest.SourceBranch"),
     );
-    if (provider === "TfsGit") {
+    // Set provider-specific properties
+    if (provider === AzureProvider.TfsGit) {
       // sonar.pullrequest.provider is deprecated in 8.1 and dropped between 8.1-8.9
       // We keep this to support legacy versions of SQ and due to the fact that scanner
       // is not rejecting this property. However we should drop it later on
       props["sonar.pullrequest.provider"] = "vsts";
       props["sonar.pullrequest.vsts.instanceUrl"] = collectionUrl;
       props["sonar.pullrequest.vsts.project"] = tl.getVariable("System.TeamProject");
-      props["sonar.pullrequest.vsts.repository"] = tl.getVariable(REPO_NAME_VAR);
-    } else if (provider === "GitHub" || provider === "GitHubEnterprise") {
+      props["sonar.pullrequest.vsts.repository"] = tl.getVariable(
+        AzureBuildVariables.BuildRepositoryName,
+      );
+    } else if (provider === AzureProvider.GitHub || provider === AzureProvider.GitHubEnterprise) {
       props["sonar.pullrequest.key"] = tl.getVariable("System.PullRequest.PullRequestNumber");
       props["sonar.pullrequest.provider"] = "github";
-      props["sonar.pullrequest.github.repository"] = tl.getVariable(REPO_NAME_VAR);
-    } else if (provider === "Bitbucket") {
+      props["sonar.pullrequest.github.repository"] = tl.getVariable(
+        AzureBuildVariables.BuildRepositoryName,
+      );
+    } else if (provider === AzureProvider.Bitbucket) {
       props["sonar.pullrequest.provider"] = "bitbucketcloud";
     } else {
       tl.warning(`Unsupported PR provider '${provider}'`);
       props["sonar.scanner.skip"] = "true";
     }
-  } else {
-    let isDefaultBranch = true;
-    const currentBranch = tl.getVariable("Build.SourceBranch");
-    if (provider === "TfsGit") {
-      isDefaultBranch = currentBranch === (await getDefaultBranch(collectionUrl));
-    } else if (provider === "Git" || provider === "GitHub" || provider === "GitHubEnterprise") {
-      // TODO for GitHub we should get the default branch configured on the repo
-      isDefaultBranch = currentBranch === "refs/heads/master";
-    } else if (provider === "Bitbucket") {
-      // TODO for Bitbucket Cloud we should get the main branch configured on the repo
-      isDefaultBranch = currentBranch === "refs/heads/master";
-    } else if (provider === "Svn") {
-      isDefaultBranch = currentBranch === "trunk";
-    }
-    if (!isDefaultBranch) {
-      // VSTS-165 don't use Build.SourceBranchName
-      props["sonar.branch.name"] = branchName(tl.getVariable("Build.SourceBranch"));
-    }
+  } else if (!isDefaultBranch()) {
+    // If analyzing a branch and not on default branch, specify branch
+    props["sonar.branch.name"] = getBranchNameFromRef(tl.getVariable("Build.SourceBranch"));
   }
 }
 
 /**
- * Waiting for https://github.com/Microsoft/vsts-tasks/issues/7591
+ * In the case of branch analysis, we need to know if we are on the default branch.
+ * If that is the case, we try to not specify the sonar.branch.name parameter to avoid getting
+ * rejected by SonarQube Communnity Edition.
  */
-function branchName(fullName: string) {
-  if (fullName.startsWith("refs/heads/")) {
-    return fullName.substring("refs/heads/".length);
+async function isDefaultBranch() {
+  const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
+  const provider = tl.getVariable("Build.Repository.Provider") as AzureProvider;
+  const currentBranch = tl.getVariable("Build.SourceBranch");
+
+  if (provider === AzureProvider.TfsGit) {
+    return currentBranch === (await getDefaultBranch(collectionUrl));
   }
-  return fullName;
+
+  if (provider === AzureProvider.Svn) {
+    return currentBranch === "trunk";
+  }
+
+  // For these providers, we can not know what is the default branch for projects.
+  // Therefore, we assume that if the branch is called master, then it is the default one.
+  // @see Feature request https://developercommunity.visualstudio.com/t/Add-a-variable-with-the-name-of-the-defa/10400800
+  if (
+    [
+      AzureProvider.Git,
+      AzureProvider.GitHub,
+      AzureProvider.GitHubEnterprise,
+      AzureProvider.Bitbucket,
+    ].includes(provider)
+  ) {
+    tl.debug(
+      `Unable to get default branch with provider ${provider}, assuming 'master' is the default branch.`,
+    );
+    return currentBranch === DEFAULT_BRANCH_REF;
+  }
+
+  return false;
 }
 
 /**
- * Waiting for https://github.com/Microsoft/vsts-tasks/issues/7592
- * query the repo to get the full name of the default branch.
- * @param collectionUrl
+ * We compute the branch name from the full ref, @see VSTS-165 Don't use Build.SourceBranchName
  */
-export async function getDefaultBranch(collectionUrl: string) {
-  const DEFAULT = "refs/heads/master";
+function getBranchNameFromRef(fullName: string) {
+  return fullName.replace(/^refs\/heads\//, "");
+}
+
+/**
+ * Query Azure Repo to get the full name of the default branch
+ */
+export async function getDefaultBranch(collectionUrl: string): Promise<string | null> {
   try {
     const vsts = getWebApi(collectionUrl);
     const gitApi = await vsts.getGitApi();
     const repo = await gitApi.getRepository(
-      tl.getVariable(REPO_NAME_VAR),
+      tl.getVariable(AzureBuildVariables.BuildRepositoryName),
       tl.getVariable("System.TeamProject"),
     );
     tl.debug(`Default branch of this repository is '${repo.defaultBranch}'`);
     return repo.defaultBranch;
   } catch (e) {
     tl.debug("Unable to get default branch, defaulting to 'master': " + e);
-    return DEFAULT;
+    return DEFAULT_BRANCH_REF;
   }
 }

--- a/commonv5/ts/sonarqube/Analysis.ts
+++ b/commonv5/ts/sonarqube/Analysis.ts
@@ -19,7 +19,7 @@ interface Condition {
   warningThreshold?: string;
 }
 
-const textStyle = (color: string = "#3E4357") => `
+const textStyle = (color = "#3E4357") => `
   color: ${color};
   font-family: Inter;
   font-size: 14px;

--- a/commonv5/ts/sonarqube/Endpoint.ts
+++ b/commonv5/ts/sonarqube/Endpoint.ts
@@ -3,7 +3,7 @@ import { RequestInit } from "node-fetch";
 import proxyAgent from "proxy-agent";
 import { getProxyForUrl } from "proxy-from-env";
 import * as semver from "semver";
-import { PROP_NAMES } from "../helpers/utils";
+import { PROP_NAMES } from "../helpers/constants";
 
 const REQUEST_TIMEOUT = 60000;
 

--- a/commonv5/ts/sonarqube/Endpoint.ts
+++ b/commonv5/ts/sonarqube/Endpoint.ts
@@ -55,9 +55,8 @@ export default class Endpoint {
 
     // Add HTTP auth from this.auth
     options.headers = {
-      Authorization: `Basic ${Buffer.from(`${this.auth.username}:${this.auth.password}`).toString(
-        "base64",
-      )}`,
+      Authorization:
+        "Basic " + Buffer.from(`${this.auth.username}:${this.auth.password}`).toString("base64"),
     };
 
     // Add proxy configuration, when relevant

--- a/commonv5/ts/sonarqube/Scanner.ts
+++ b/commonv5/ts/sonarqube/Scanner.ts
@@ -1,7 +1,8 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { PROP_NAMES, isWindows } from "../helpers/utils";
+import { PROP_NAMES } from "../helpers/constants";
+import { isWindows } from "../helpers/utils";
 
 export enum ScannerMode {
   MSBuild = "MSBuild",

--- a/commonv5/ts/sonarqube/Scanner.ts
+++ b/commonv5/ts/sonarqube/Scanner.ts
@@ -1,7 +1,7 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { TaskVariables, PROP_NAMES } from "../helpers/constants";
+import { PROP_NAMES, TaskVariables } from "../helpers/constants";
 import { isWindows } from "../helpers/utils";
 
 export enum ScannerMode {
@@ -116,7 +116,7 @@ export class ScannerCLI extends Scanner {
   constructor(
     rootPath: string,
     private readonly data: ScannerCLIData,
-    private cliMode?: string,
+    private readonly cliMode?: string,
   ) {
     super(rootPath, ScannerMode.CLI);
   }

--- a/commonv5/ts/sonarqube/Scanner.ts
+++ b/commonv5/ts/sonarqube/Scanner.ts
@@ -1,7 +1,7 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { PROP_NAMES } from "../helpers/constants";
+import { TaskVariables, PROP_NAMES } from "../helpers/constants";
 import { isWindows } from "../helpers/utils";
 
 export enum ScannerMode {
@@ -197,12 +197,12 @@ export class ScannerMSBuild extends Scanner {
     if (isWindows()) {
       const scannerExePath = this.findFrameworkScannerPath();
       tl.debug(`Using classic scanner at ${scannerExePath}`);
-      tl.setVariable("SONARQUBE_SCANNER_MSBUILD_EXE", scannerExePath);
+      tl.setVariable(TaskVariables.SonarQubeScannerMSBuildExe, scannerExePath);
       scannerRunner = this.getScannerRunner(scannerExePath, true);
     } else {
       const scannerDllPath = this.findDotnetScannerPath();
       tl.debug(`Using dotnet scanner at ${scannerDllPath}`);
-      tl.setVariable("SONARQUBE_SCANNER_MSBUILD_DLL", scannerDllPath);
+      tl.setVariable(TaskVariables.SonarQubeScannerMSBuildDll, scannerDllPath);
       scannerRunner = this.getScannerRunner(scannerDllPath, false);
 
       // Need to set executable flag on the embedded scanner CLI
@@ -250,8 +250,8 @@ export class ScannerMSBuild extends Scanner {
 
   public async runAnalysis() {
     const scannerRunner = isWindows()
-      ? this.getScannerRunner(tl.getVariable("SONARQUBE_SCANNER_MSBUILD_EXE"), true)
-      : this.getScannerRunner(tl.getVariable("SONARQUBE_SCANNER_MSBUILD_DLL"), false);
+      ? this.getScannerRunner(tl.getVariable(TaskVariables.SonarQubeScannerMSBuildExe), true)
+      : this.getScannerRunner(tl.getVariable(TaskVariables.SonarQubeScannerMSBuildDll), false);
 
     scannerRunner.arg("end");
     this.logIssueOnBuildSummaryForStdErr(scannerRunner);

--- a/commonv5/ts/sonarqube/TaskReport.ts
+++ b/commonv5/ts/sonarqube/TaskReport.ts
@@ -4,6 +4,7 @@ import { Guid } from "guid-typescript";
 import * as path from "path";
 import * as semver from "semver";
 import Endpoint, { EndpointType } from "./Endpoint";
+import { TaskVariables } from "../helpers/constants";
 
 export const REPORT_TASK_NAME = "report-task.txt";
 export const SONAR_TEMP_DIRECTORY_NAME = "sonar";
@@ -74,8 +75,8 @@ export default class TaskReport {
       );
       taskReportGlob = path.join("**", REPORT_TASK_NAME);
       taskReportGlobResult = tl.findMatch(tl.getVariable("Agent.BuildDirectory"), taskReportGlob);
-    } else if (tl.getVariable("SONARQUBE_SCANNER_REPORTTASKFILE")) {
-      taskReportGlob = tl.getVariable("SONARQUBE_SCANNER_REPORTTASKFILE");
+    } else if (tl.getVariable(TaskVariables.SonarQubeScannerReportTaskFile)) {
+      taskReportGlob = tl.getVariable(TaskVariables.SonarQubeScannerReportTaskFile);
       taskReportGlobResult = tl.find(taskReportGlob);
     } else {
       taskReportGlob = TaskReport.getDefaultPathGlob();

--- a/commonv5/ts/sonarqube/__tests__/Endpoint-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/Endpoint-test.ts
@@ -1,5 +1,5 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import { PROP_NAMES } from "../../helpers/utils";
+import { PROP_NAMES } from "../../helpers/constants";
 import Endpoint, { EndpointType } from "../Endpoint";
 
 beforeEach(() => {

--- a/commonv5/ts/sonarqube/__tests__/TaskReport-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/TaskReport-test.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from "fs";
 import * as path from "path";
 import * as semver from "semver";
 import { fileSync } from "tmp";
+import { TaskVariables } from "../../helpers/constants";
 import Endpoint, { EndpointType } from "../Endpoint";
 import TaskReport from "../TaskReport";
 
@@ -105,7 +106,7 @@ it.each([
   expect(reportFiles[1]).toBe("path2");
 
   expect(tl.getVariable).toHaveBeenCalledTimes(2);
-  expect(tl.getVariable).toBeCalledWith("SONARQUBE_SCANNER_REPORTTASKFILE");
+  expect(tl.getVariable).toHaveBeenCalledWith(TaskVariables.SonarQubeScannerReportTaskFile);
 
   // Calculate the expected path to take account of different
   // path separators in Windows/non-Windows


### PR DESCRIPTION
**VSTS-221 Document logic to decide whether we are on the main branch or not**

In the end, I decided to keep the same logic than currently. It is not worth it IMO to take risk to break Developer+ instances to have Community Edition supporting main branch with other names than `master`

The current behavior is:
- For azure repos, we send the property if the analyzed branch is not the default branch. If the Web API can not be reached, the fallback is to send the property only if the analyzed branch is not `master`.
- For SVN, we send the property if the analyzed branch is not `trunk`. 
- For other providers we send the property if and only if the branch is not `master`

This PR focuses on code quality and documentation to make the current behavior clear

____

**VSTS-309 Fail fast if required properties do not exist**

Adds a verbose error message:
- Asking to add the prepare task before the analyze task
- Asking to add the prepare task and analyze task before the publish task
- Specifying that multistage pipelines are not supported (if using multiple stages)
- Specifying that major task versions should not be mixed 

Also added an enum for all the custom variables we use. IMO there was no need to list all the required variables and ensure they were all here at the beginning of the analysis and publish tasks because if one of the required variables is not there, others will not be there as well. I went for [KISS](https://en.wikipedia.org/wiki/KISS_principle)

![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/acadeff7-3c56-465c-81b2-331af836655b)
