### PR TITLE
[NO-JIRA] Bump SonarQube and V5 task versions

### DIFF
--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -11,8 +11,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 17,
-    "Patch": 2
+    "Minor": 18,
+    "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/prepare/v5/task.json
+++ b/extensions/sonarqube/tasks/prepare/v5/task.json
@@ -11,8 +11,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 17,
-    "Patch": 2
+    "Minor": 18,
+    "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/publish/v5/task.json
+++ b/extensions/sonarqube/tasks/publish/v5/task.json
@@ -11,8 +11,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 4,
-    "Patch": 2
+    "Minor": 5,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "inputs": [

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.17.2",
+  "version": "5.18.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
Bump version of the SQ extension and its V5 tasks

We will not be releasing the SC extension so that we do not disrupt with your plans, in case work needs to be done after the release. We will extend functional validation related to our hardening sprint to SC to avoid any surprise when you do the SC release.

@quentin-chevrin-sonarsource @alexandre-holzhey-sonarsource @ivan-murenko-sonarsource 