### PR TITLE
[NO-JIRA] Assume default branch when no provider is detected

### DIFF
--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -20,7 +20,7 @@ export enum AzureProvider {
   Bitbucket = "Bitbucket",
 }
 
-export const DEFAULT_BRANCH_NAME = "refs/heads/master";
+export const DEFAULT_BRANCH_REF = "refs/heads/master";
 
 export enum AzureBuildVariables {
   BuildRepositoryName = "Build.Repository.Name",

--- a/commonv5/ts/prepare-task.ts
+++ b/commonv5/ts/prepare-task.ts
@@ -4,7 +4,7 @@ import { getWebApi, parseScannerExtraProperties } from "./helpers/azdo-api-utils
 import {
   AzureBuildVariables,
   AzureProvider,
-  DEFAULT_BRANCH_NAME as DEFAULT_BRANCH_REF,
+  DEFAULT_BRANCH_REF,
   TaskVariables,
 } from "./helpers/constants";
 import { getServerVersion } from "./helpers/request";
@@ -148,7 +148,7 @@ async function isDefaultBranch() {
     return currentBranch === DEFAULT_BRANCH_REF;
   }
 
-  return false;
+  return true;
 }
 
 /**

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 5,
     "Minor": 18,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/prepare/v5/task.json
+++ b/extensions/sonarqube/tasks/prepare/v5/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 5,
     "Minor": 18,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/publish/v5/task.json
+++ b/extensions/sonarqube/tasks/publish/v5/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 5,
     "Minor": 5,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "2.144.0",
   "inputs": [

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.18.1",
+  "version": "5.18.2",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
This is an attempt at fixing [this community thread](https://community.sonarsource.com/t/ado-extension-broken/104618), It is the only functional change from `5.17.2`

Although assuming that we are not on the default branch is safer for Commercial Editions, because they will not fail when the branch is set, not setting it in that particular case is consistent with the behavior of `5.17.2`, so that can technically be considered a breaking change in case a user:
- is using the Community Edition
- is not using "master" as his main branch
- has a code provider not recognized by our code

We can change this when we upgrade tasks to a next major version