### PR TITLE
NO-JIRA update base image for j17 and update scanner-npm

### DIFF
--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -11,7 +11,7 @@
 # AWS Registry. See section "eks_container" of .cirrus.yml
 #------------------------------------------------------------------------------
 ARG CIRRUS_AWS_ACCOUNT
-FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-latest
+FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
 
 USER root
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "openpgp": "5.10.1",
     "prettier": "3.0.3",
     "semver": "5.5.0",
-    "sonarqube-scanner": "3.0.0",
+    "sonarqube-scanner": "3.3.0",
     "stream": "^0.0.2",
     "tfx-cli": "0.16.0",
     "through2": "^4.0.2",


### PR DESCRIPTION
Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
Next now requires java 17 to run the scanners. The scanner-npm dependency needs to be updated to have the embedded jre updated to 17. I also updated the runtime of the docker build to be aligned with other repositories.
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)
