### PR TITLE
VSTS-343 Remove deprecated NodeJS installation in build Dockerfile

### DIFF
--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -15,9 +15,14 @@ FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
 
 USER root
 
-RUN apt-get update -y
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs libicu-dev
+RUN apt-get update -y && \
+    apt-get install -y libicu-dev ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=20
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install nodejs -y
+
 
 ENV CYCLONEDX_CLI_VERSION=v0.24.0
 ENV CYCLONEDX_CLI_SHA256=691cf7ed82ecce1f85e6d21bccd1ed2d7968e40eb6be7504b392c8b3a0943891


### PR DESCRIPTION
The way we install NodeJS in the image used during build is deprecated. We should update the image to properly install NodeJS and ensure we use NodeJS 18. This may fix the nightly build which fails because of NodeJS version mismatch (expects 16+, has 14).

This was caused by bumping `sonar-scanner-npm` from `3.0.0` to `3.3.0` because `3.1.0` includes `sonar-scanner-cli@5` 