### PR TITLE
VSTS-347 Show available measures when they are available through QG conditions even when QG passes

### DIFF
--- a/commonv5/ts/sonarqube/HtmlAnalysisReport.ts
+++ b/commonv5/ts/sonarqube/HtmlAnalysisReport.ts
@@ -71,6 +71,39 @@ export default class HtmlAnalysisReport {
     return rows.length > 0 ? htmlSectionDiv("Failed Conditions", htmlMetricList(rows)) : "";
   }
 
+  private getHtmlMeasureListItem(icon: string, metricKey: string) {
+    const condition = this.projectStatus.conditions.find((c) => c.metricKey === metricKey);
+    const metric = this.result.metrics.find((m) => m.key === metricKey);
+    if (!condition || !metric) {
+      return "";
+    }
+
+    return htmlMetricListItem(
+      icon,
+      `${formatMeasure(condition.actualValue, metric.type)} ${metric.name}`,
+    );
+  }
+
+  private getHtmlQualityGateDetailPassedSection() {
+    const issuesItems = [
+      this.getHtmlMeasureListItem("✅", "new_violations"),
+      this.getHtmlMeasureListItem("🔧", "pullrequest_addressed_issues"),
+      this.getHtmlMeasureListItem("💤", "new_accepted_issues"),
+    ].filter((item) => item.length > 0);
+    const issuesSection =
+      issuesItems.length > 0 ? htmlSectionDiv("Issues", htmlMetricList(issuesItems)) : "";
+
+    const measuresItems = [
+      this.getHtmlMeasureListItem("✅", "new_security_hotspots"),
+      this.getHtmlMeasureListItem("✅", "new_coverage"),
+      this.getHtmlMeasureListItem("✅", "new_duplicated_lines_density"),
+    ].filter((item) => item.length > 0);
+    const measuresSection =
+      measuresItems.length > 0 ? htmlSectionDiv("Measures", htmlMetricList(measuresItems)) : "";
+
+    return issuesSection + measuresSection;
+  }
+
   private getHtmlQualityGateDetailSection() {
     if (!this.result.metrics) {
       return "";
@@ -79,7 +112,7 @@ export default class HtmlAnalysisReport {
     if (["WARN", "ERROR"].includes(this.projectStatus.status)) {
       return this.getHtmlQualityGateDetailFailedSection();
     } else {
-      return "";
+      return this.getHtmlQualityGateDetailPassedSection();
     }
   }
 


### PR DESCRIPTION
The goal with this PR is to as close as possible to the expected result from UX mockup with the data we already have. Only available measures are included in the summary when the QG passes now. More information can be found in our internal VSTS ticket.

![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/ef09b4a8-1a39-417e-aef6-c25dec3a0135)
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/ed538950-ebb5-4b1c-ab4d-a12bcbaed5a7)
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/b1c95c2c-3520-46b7-bf06-4755b7130c8e)
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/801ca7e0-bcb8-47ea-bf0a-c4cb10acbd52)
