### PR TITLE
VSTS-344 VSTS-345 Show issues fixed in PR and accepted issues in build summary when possible

### DIFF
--- a/commonv5/ts/__tests__/analyze-task-test.ts
+++ b/commonv5/ts/__tests__/analyze-task-test.ts
@@ -20,6 +20,11 @@ it("should run scanner", async () => {
   jest.spyOn(tl, "getVariable").mockReturnValueOnce("CLI");
   jest.spyOn(tl, "getVariable").mockReturnValueOnce("CLI");
 
+  //SONARQUBE_SCANNER_PARAMS
+  jest
+    .spyOn(tl, "getVariable")
+    .mockReturnValueOnce('{"sonar.metadata": "/home/user/metadata.txt"}');
+
   //JAVA_HOME
   jest.spyOn(tl, "getVariable").mockReturnValueOnce("/home/path/to/java");
 

--- a/commonv5/ts/__tests__/publish-task-test.ts
+++ b/commonv5/ts/__tests__/publish-task-test.ts
@@ -27,10 +27,16 @@ const TASK_REPORT = new TaskReport({
 });
 
 const PROJECT_STATUS_OK: ProjectStatus = {
-  conditions: [],
+  conditions: [
+    {
+      metricKey: "new_coverage",
+      status: "OK",
+      actualValue: "100",
+    },
+  ],
   status: "OK",
 };
-const ANALYSIS_OK = new HtmlAnalysisReport(PROJECT_STATUS_OK, {
+const ANALYSIS_OK = new HtmlAnalysisReport(PROJECT_STATUS_OK, [], {
   warnings: [],
   dashboardUrl: "",
   metrics: null,
@@ -41,7 +47,7 @@ const PROJECT_STATUS_ERROR: ProjectStatus = {
   conditions: [],
   status: "ERROR",
 };
-const ANALYSIS_ERROR = new HtmlAnalysisReport(PROJECT_STATUS_ERROR, {
+const ANALYSIS_ERROR = new HtmlAnalysisReport(PROJECT_STATUS_ERROR, [], {
   warnings: [],
   dashboardUrl: "",
   metrics: null,
@@ -50,7 +56,23 @@ const ANALYSIS_ERROR = new HtmlAnalysisReport(PROJECT_STATUS_ERROR, {
 
 const SC_ENDPOINT = new Endpoint(EndpointType.SonarCloud, { url: "https://endpoint.url" });
 const SQ_ENDPOINT = new Endpoint(EndpointType.SonarQube, { url: "https://endpoint.url" });
-const METRICS: Metric[] = [];
+const METRICS: Metric[] = [
+  {
+    key: "new_violations",
+    name: "New issues",
+    type: "INT",
+  },
+  {
+    key: "new_coverage",
+    name: "Coverage on new code",
+    type: "PERCENT",
+  },
+  {
+    key: "pull_request_fixed_issues",
+    name: "Issues fixed in this pull request",
+    type: "INT",
+  },
+];
 
 it("should fail unless SONARQUBE_SCANNER_PARAMS are supplied", async () => {
   jest.spyOn(tl, "getVariable").mockImplementation(() => undefined);
@@ -236,8 +258,10 @@ it("get report string for single report", async () => {
   jest.spyOn(Task, "waitForTaskCompletion").mockResolvedValue(returnedTask);
 
   jest.spyOn(api, "fetchProjectStatus").mockResolvedValueOnce(PROJECT_STATUS_OK);
+
   jest.spyOn(HtmlAnalysisReport, "getInstance").mockReturnValueOnce(ANALYSIS_OK);
   jest.spyOn(ANALYSIS_OK, "getHtmlAnalysisReport").mockImplementation(() => "dummy html");
+  jest.spyOn(tl, "getVariable").mockImplementationOnce(() => "{}");
 
   const result = await publishTask.getReportForTask(TASK_REPORT, METRICS, SQ_ENDPOINT, 999);
 
@@ -315,5 +339,124 @@ it("task should not fail the task even if all ceTasks timeout", async () => {
   );
   expect(tl.warning).toHaveBeenCalledWith(
     "Task '222' takes too long to complete. Stopping after 1s of polling. No quality gate will be displayed on build result.",
+  );
+});
+
+describe("it should generate passing report correctly", () => {
+  beforeEach(() => {
+    tl.setVariable(TaskVariables.SonarQubeScannerParams, "{}");
+    jest.spyOn(request, "getServerVersion").mockResolvedValue(new SemVer("10.4.0"));
+
+    jest.spyOn(tl, "getInput").mockImplementation(() => "1"); // set the timeout
+    jest.spyOn(tl, "setResult");
+    jest.spyOn(tl, "debug").mockImplementation(() => null);
+    jest.spyOn(tl, "warning").mockImplementation(() => null);
+
+    // Mock metrics
+    jest.spyOn(api, "fetchMetrics").mockResolvedValue(METRICS);
+
+    // Mock waiting for the ceTask to complete and return a Task
+    const returnedTask = new Task({
+      analysisId: "123",
+      componentKey: "projectKey1",
+      status: "status",
+      type: EndpointType.SonarQube,
+      componentName: "componentName",
+      warnings: [],
+    });
+
+    // Mock finding the report file to process
+    jest.spyOn(TaskReport, "createTaskReportsFromFiles").mockResolvedValue([TASK_REPORT]);
+    jest.spyOn(Task, "waitForTaskCompletion").mockResolvedValue(returnedTask);
+
+    jest.spyOn(apiUtils, "addBuildProperty").mockResolvedValue(null);
+    jest.spyOn(apiUtils, "getAuthToken").mockImplementation(() => null);
+    jest.spyOn(serverUtils, "fillBuildProperty").mockImplementation(() => null);
+    jest.spyOn(serverUtils, "publishBuildSummary").mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("not fail when measures can not be retrieved", async () => {
+    tl.setVariable(TaskVariables.SonarQubeEndpoint, SQ_ENDPOINT.toJson());
+    jest.spyOn(api, "fetchProjectStatus").mockResolvedValueOnce(PROJECT_STATUS_OK);
+
+    await publishTask.default(EndpointType.SonarQube);
+
+    expect(tl.debug).toHaveBeenCalledWith(
+      "Unable to get measures. It is expected if you are not using a user token but instead a global or project analysis token.",
+    );
+  });
+
+  it("should show available fetched measures", async () => {
+    tl.setVariable(TaskVariables.SonarQubeEndpoint, SQ_ENDPOINT.toJson());
+    jest.spyOn(api, "fetchProjectStatus").mockResolvedValueOnce(PROJECT_STATUS_OK);
+    jest.spyOn(api, "fetchComponentMeasures").mockResolvedValueOnce([
+      {
+        metric: "new_violations",
+        value: "10",
+      },
+    ]);
+
+    await publishTask.default(EndpointType.SonarQube);
+
+    // spy on publishBuildSummary
+    expect(serverUtils.publishBuildSummary).toHaveBeenCalledTimes(1);
+    const buildSummary = (serverUtils.publishBuildSummary as any).mock.calls[0][0];
+    expect(buildSummary).toMatch("Quality Gate passed (componentName)");
+    expect(buildSummary).toMatch("10 new issues");
+    expect(buildSummary).toMatch("100% Coverage on new code");
+  });
+
+  it("should not fail when no measure/metric is available", async () => {
+    tl.setVariable(TaskVariables.SonarQubeEndpoint, SQ_ENDPOINT.toJson());
+    jest
+      .spyOn(api, "fetchProjectStatus")
+      .mockResolvedValueOnce({ ...PROJECT_STATUS_OK, conditions: [] });
+    jest.spyOn(api, "fetchComponentMeasures").mockResolvedValueOnce([]);
+
+    await publishTask.default(EndpointType.SonarQube);
+
+    // spy on publishBuildSummary
+    expect(serverUtils.publishBuildSummary).toHaveBeenCalledTimes(1);
+    const buildSummary = (serverUtils.publishBuildSummary as any).mock.calls[0][0];
+    expect(buildSummary).toMatch("Quality Gate passed (componentName)");
+  });
+
+  it.each([
+    [EndpointType.SonarQube, SQ_ENDPOINT, { "sonar.pullrequest.key": "123" }, true],
+    [EndpointType.SonarQube, SQ_ENDPOINT, {}, false],
+    [EndpointType.SonarQube, SQ_ENDPOINT, { "sonar.branch.name": "some-branch" }, false],
+    [EndpointType.SonarCloud, SC_ENDPOINT, { "sonar.pullrequest.key": "123" }, false],
+  ])(
+    "should show issues fixed in pull request for sonarqube",
+    async (endpointType, endpoint, scannerParams, shouldShow) => {
+      tl.setVariable(TaskVariables.SonarQubeEndpoint, endpoint.toJson());
+      tl.setVariable(TaskVariables.SonarQubeScannerParams, JSON.stringify(scannerParams));
+      jest.spyOn(api, "fetchProjectStatus").mockResolvedValueOnce(PROJECT_STATUS_OK);
+      jest.spyOn(api, "fetchComponentMeasures").mockImplementation((_endpoint, { metricKeys }) => {
+        return Promise.resolve(
+          metricKeys.split(",").map((metricKey) => {
+            return {
+              metric: metricKey,
+              value: "32",
+            };
+          }),
+        );
+      });
+
+      await publishTask.default(endpointType);
+
+      // Check build summary
+      expect(serverUtils.publishBuildSummary).toHaveBeenCalledTimes(1);
+      const buildSummary = (serverUtils.publishBuildSummary as any).mock.calls[0][0];
+      if (shouldShow) {
+        expect(buildSummary).toMatch("32 fixed issues");
+      } else {
+        expect(buildSummary).not.toMatch("32 fixed issues");
+      }
+    },
   );
 });

--- a/commonv5/ts/helpers/__tests__/utils-test.ts
+++ b/commonv5/ts/helpers/__tests__/utils-test.ts
@@ -1,20 +1,28 @@
-import { sanitizeVariable, toCleanJSON } from "../utils";
+import { sanitizeScannerParams, stringifyScannerParams } from "../utils";
 
 describe("toCleanJSON", () => {
   it("should jsonify", () => {
-    expect(toCleanJSON({ foo: "a", bar: "b" })).toBe('{"foo":"a","bar":"b"}');
+    expect(stringifyScannerParams({ foo: "a", bar: "b" })).toBe('{"foo":"a","bar":"b"}');
   });
   it("should clean the jsonified object", () => {
-    expect(toCleanJSON({ foo: "a", bar: undefined, baz: "" })).toBe('{"foo":"a","baz":""}');
+    expect(stringifyScannerParams({ foo: "a", bar: undefined, baz: "" })).toBe(
+      '{"foo":"a","baz":""}',
+    );
   });
 });
 
 describe("sanitizeVariable", () => {
   it("should sanitize username and pass", () => {
     expect(
-      sanitizeVariable(
-        '{ "foo": "a", "bar": "b", "sonar.login": "aaabbbccc", "sonar.password": "fffjjjkkk" }',
-      ),
-    ).toBe('{"foo":"a","bar":"b"}');
+      sanitizeScannerParams({
+        foo: "a",
+        bar: "b",
+        "sonar.login": "aaabbbccc",
+        "sonar.password": "fffjjjkkk",
+      }),
+    ).toStrictEqual({
+      foo: "a",
+      bar: "b",
+    });
   });
 });

--- a/commonv5/ts/helpers/api.ts
+++ b/commonv5/ts/helpers/api.ts
@@ -1,7 +1,13 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import { get } from "./request";
 import Endpoint from "../sonarqube/Endpoint";
-import { Metric, MetricsResponse, ProjectStatus } from "../sonarqube/types";
+import {
+  Measure,
+  MeasureResponse,
+  Metric,
+  MetricsResponse,
+  ProjectStatus,
+} from "../sonarqube/types";
+import { get } from "./request";
 
 export async function fetchProjectStatus(
   endpoint: Endpoint,
@@ -24,6 +30,9 @@ export async function fetchProjectStatus(
   }
 }
 
+/**
+ * @param prev Parameter used for recursive calls. Do not use.
+ */
 export async function fetchMetrics(
   endpoint: Endpoint,
   data: { f?: string; p?: number; ps?: number } = { f: "name", ps: 500 },
@@ -45,5 +54,28 @@ export async function fetchMetrics(
     }
 
     throw new Error(`Could not fetch metrics`);
+  }
+}
+
+export async function fetchComponentMeasures(
+  endpoint: Endpoint,
+  data: { component: string; branch?: string; pullRequest?: string; metricKeys: string },
+): Promise<Measure[]> {
+  try {
+    const response = (await get(
+      endpoint,
+      "/api/measures/component",
+      true,
+      data,
+    )) as MeasureResponse;
+    return response.component.measures;
+  } catch (error) {
+    if (error?.message) {
+      tl.debug("Error fetching component measures: " + error.message);
+    } else if (error) {
+      tl.debug("Error fetching component measures: " + JSON.stringify(error));
+    }
+
+    throw new Error(`Could not fetch component measures`);
   }
 }

--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -38,3 +38,20 @@ export enum TaskVariables {
 }
 
 export const TASK_MISSING_VARIABLE_ERROR_HINT = `Make sure you are not mixing tasks from different major versions. If you are using a multistage pipeline, make sure the tasks are in the same stage.`;
+
+export const SQ_PULLREQUEST_MEASURES = [
+  "new_violations",
+  "pull_request_fixed_issues",
+  "new_accepted_issues",
+  "new_security_hotspots",
+  "new_coverage",
+  "new_duplicated_lines_density",
+];
+
+export const SQ_BRANCH_MEASURES = [
+  "new_violations",
+  "new_accepted_issues",
+  "new_security_hotspots",
+  "new_coverage",
+  "new_duplicated_lines_density",
+];

--- a/commonv5/ts/helpers/html.ts
+++ b/commonv5/ts/helpers/html.ts
@@ -67,8 +67,15 @@ export const htmlMetricListItem = (icon: string, text: string, requiredContent?:
   `.trim();
 };
 
-export const htmlQualityGateHeader = (projectStatus: ProjectStatus, projectName?: string) =>
-  htmlDiv(
+export const htmlQualityGateHeader = (projectStatus: ProjectStatus, projectName?: string) => {
+  let qgTitle: string;
+  if (projectStatus.status !== "none") {
+    qgTitle = `Quality Gate ${formatMeasure(projectStatus.status, "LEVEL")}`;
+  } else {
+    qgTitle = "No Quality Gate Status";
+  }
+  qgTitle += projectName ? ` (${projectName})` : "";
+  return htmlDiv(
     `font-size: 21px;
     font-weight: 600;`,
     [
@@ -77,8 +84,7 @@ export const htmlQualityGateHeader = (projectStatus: ProjectStatus, projectName?
         height: 100%;
         padding-top: 4px;
         margin-left: 4px;
-      ">Quality Gate ${formatMeasure(projectStatus.status, "LEVEL")} ${
-        projectName ? `(${projectName})` : ""
-      }</span>`,
+      ">${qgTitle}</span>`,
     ].join(""),
   );
+};

--- a/commonv5/ts/helpers/utils.ts
+++ b/commonv5/ts/helpers/utils.ts
@@ -1,19 +1,19 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import { PROP_NAMES } from "./constants";
 
-export function toCleanJSON(props: { [key: string]: string | undefined }) {
+type ScannerParams = { [key: string]: string | undefined };
+
+export function stringifyScannerParams(scannerParams: ScannerParams) {
   return JSON.stringify(
-    props,
-    Object.keys(props).filter((key) => props[key] != null),
+    scannerParams,
+    Object.keys(scannerParams).filter((key) => scannerParams[key] != null),
   );
 }
 
-export function sanitizeVariable(jsonPayload: string) {
-  const jsonObj = JSON.parse(jsonPayload);
-  delete jsonObj[PROP_NAMES.LOGIN];
-  delete jsonObj[PROP_NAMES.PASSSWORD];
-  jsonPayload = toCleanJSON(jsonObj);
-  return jsonPayload;
+export function sanitizeScannerParams(scannerParams: ScannerParams) {
+  delete scannerParams[PROP_NAMES.LOGIN];
+  delete scannerParams[PROP_NAMES.PASSSWORD];
+  return scannerParams;
 }
 
 export function isWindows() {

--- a/commonv5/ts/prepare-task.ts
+++ b/commonv5/ts/prepare-task.ts
@@ -8,7 +8,7 @@ import {
   TaskVariables,
 } from "./helpers/constants";
 import { getServerVersion } from "./helpers/request";
-import { toCleanJSON } from "./helpers/utils";
+import { stringifyScannerParams } from "./helpers/utils";
 import Endpoint, { EndpointType } from "./sonarqube/Endpoint";
 import Scanner, { ScannerMode } from "./sonarqube/Scanner";
 import TaskReport from "./sonarqube/TaskReport";
@@ -52,7 +52,7 @@ export default async function prepareTask(endpoint: Endpoint, rootPath: string) 
   tl.setVariable(TaskVariables.SonarQubeScannerMode, scannerMode);
   tl.setVariable(TaskVariables.SonarQubeEndpoint, endpoint.toJson(), true);
 
-  const jsonParams = toCleanJSON({
+  const jsonParams = stringifyScannerParams({
     ...endpoint.toSonarProps(serverVersion),
     ...scanner.toSonarProps(),
     ...props,

--- a/commonv5/ts/sonarqube/Task.ts
+++ b/commonv5/ts/sonarqube/Task.ts
@@ -24,6 +24,10 @@ export default class Task {
     return this.task.componentName;
   }
 
+  public get componentKey() {
+    return this.task.componentKey;
+  }
+
   public get warnings() {
     if (this.task.warnings) {
       return this.task.warnings;

--- a/commonv5/ts/sonarqube/__tests__/HtmlAnalysisReport-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/HtmlAnalysisReport-test.ts
@@ -1,13 +1,13 @@
 import HtmlAnalysisReport from "../HtmlAnalysisReport";
 import { AnalysisResult, Metric } from "../types";
 
-const MOCKED_METRICS: Metric[] = [{ key: "bugs", name: "Bugs", type: "INT" }];
+const MOCKED_METRICS: Metric[] = [{ key: "new_violations", name: "Bugs", type: "INT" }];
 const MOCKED_PROJECT_STATUS_ERROR = {
   status: "ERROR",
   conditions: [
     {
       status: "ERROR",
-      metricKey: "bugs",
+      metricKey: "new_violations",
       comparator: "GT",
       errorThreshold: "0",
       actualValue: "1",
@@ -16,7 +16,15 @@ const MOCKED_PROJECT_STATUS_ERROR = {
 };
 const MOCKED_PROJECT_STATUS_SUCCESS = {
   status: "OK",
-  conditions: [],
+  conditions: [
+    {
+      status: "OK",
+      metricKey: "new_violations",
+      comparator: "GT",
+      errorThreshold: "0",
+      actualValue: "0",
+    },
+  ],
 };
 const MOCKED_ANALYSIS_RESULT: AnalysisResult = {
   dashboardUrl: "https://dashboard.url",
@@ -32,21 +40,14 @@ jest.mock("azure-pipelines-task-lib/task", () => ({
 }));
 
 it("should generate an analysis status with error", () => {
-  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_ERROR, MOCKED_ANALYSIS_RESULT);
+  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_ERROR, [], MOCKED_ANALYSIS_RESULT);
 
   expect(analysis.getFailedConditions()).toHaveLength(1);
   expect(analysis.getHtmlAnalysisReport()).toMatchSnapshot();
 });
 
-it("should generate a green analysis status", () => {
-  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_SUCCESS, MOCKED_ANALYSIS_RESULT);
-
-  expect(analysis.getFailedConditions()).toHaveLength(0);
-  expect(analysis.getHtmlAnalysisReport()).toMatchSnapshot();
-});
-
 it("should not fail when metrics are missing", () => {
-  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_ERROR, {
+  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_ERROR, [], {
     ...MOCKED_ANALYSIS_RESULT,
     dashboardUrl: undefined,
     metrics: undefined,
@@ -56,8 +57,35 @@ it("should not fail when metrics are missing", () => {
   expect(analysis.getHtmlAnalysisReport()).toMatchSnapshot();
 });
 
+it("should render passing quality gate measures correctly", () => {
+  const analysis = new HtmlAnalysisReport(
+    MOCKED_PROJECT_STATUS_SUCCESS,
+    [
+      {
+        metric: "new_violations",
+        value: "1",
+      },
+      {
+        metric: "pull_request_fixed_issues",
+        period: {
+          value: "2",
+          index: 1,
+        },
+      },
+      {
+        metric: "new_coverage",
+        value: "23",
+      },
+    ],
+    MOCKED_ANALYSIS_RESULT,
+  );
+
+  expect(analysis.getFailedConditions()).toHaveLength(0);
+  expect(analysis.getHtmlAnalysisReport()).toMatchSnapshot();
+});
+
 it("should display the project name", () => {
-  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_ERROR, {
+  const analysis = new HtmlAnalysisReport(MOCKED_PROJECT_STATUS_ERROR, [], {
     ...MOCKED_ANALYSIS_RESULT,
     projectName: "project_name",
   });

--- a/commonv5/ts/sonarqube/__tests__/__snapshots__/HtmlAnalysisReport-test.ts.snap
+++ b/commonv5/ts/sonarqube/__tests__/__snapshots__/HtmlAnalysisReport-test.ts.snap
@@ -40,33 +40,6 @@ exports[`should display the project name 1`] = `
   >See analysis details on SonarQube</a></div></div>"
 `;
 
-exports[`should generate a green analysis status 1`] = `
-"<div style="font-family: Inter;
-    font-size: 14px;
-    font-style: normal;
-    line-height: normal;
-    font-weight: 400;
-    color: rgb(29, 33, 47);
-    padding-bottom: 1px;"><div style="font-size: 21px;
-    font-weight: 600;"><span>✅</span><span style="
-        height: 100%;
-        padding-top: 4px;
-        margin-left: 4px;
-      ">Quality Gate passed </span></div><div style="background: #EBECF0;
-    height: 1px;
-    margin: 16px 0px;"></div><div style="margin-top: 24px;
-      padding-left: 28px;"><a
-    style="
-      color: rgb(9, 105, 218);
-      text-decoration: none;
-      border-bottom: 1px solid rgb(9, 105, 218);
-      font-weight: 500;
-      width: fit-content; 
-    "
-    href="https://dashboard.url"
-  >See analysis details on SonarQube</a></div></div>"
-`;
-
 exports[`should generate an analysis status with error 1`] = `
 "<div style="font-family: Inter;
     font-size: 14px;
@@ -79,7 +52,7 @@ exports[`should generate an analysis status with error 1`] = `
         height: 100%;
         padding-top: 4px;
         margin-left: 4px;
-      ">Quality Gate failed </span></div><div style="background: #EBECF0;
+      ">Quality Gate failed</span></div><div style="background: #EBECF0;
     height: 1px;
     margin: 16px 0px;"></div><div style="margin-top: 24px;"><div style="margin-bottom: 12px;">Failed Conditions</div><ul
     style="
@@ -119,7 +92,47 @@ exports[`should not fail when metrics are missing 1`] = `
         height: 100%;
         padding-top: 4px;
         margin-left: 4px;
-      ">Quality Gate failed </span></div><div style="background: #EBECF0;
+      ">Quality Gate failed</span></div><div style="background: #EBECF0;
     height: 1px;
     margin: 16px 0px;"></div></div>"
+`;
+
+exports[`should render passing quality gate measures correctly 1`] = `
+"<div style="font-family: Inter;
+    font-size: 14px;
+    font-style: normal;
+    line-height: normal;
+    font-weight: 400;
+    color: rgb(29, 33, 47);
+    padding-bottom: 1px;"><div style="font-size: 21px;
+    font-weight: 600;"><span>✅</span><span style="
+        height: 100%;
+        padding-top: 4px;
+        margin-left: 4px;
+      ">Quality Gate passed</span></div><div style="background: #EBECF0;
+    height: 1px;
+    margin: 16px 0px;"></div><div style="margin-top: 24px;"><div style="margin-bottom: 12px;">Issues</div><ul
+    style="
+      padding: 0;
+      margin: 0;
+    "
+  ><li
+      style="
+        list-style: none;
+        align-items: center;
+        margin-top: 8px;
+      "
+    ><span style="width: 24px">✅</span>
+<span style="margin-left: 4px">1 new issues</span>
+</li></ul></div><div style="margin-top: 24px;
+      padding-left: 28px;"><a
+    style="
+      color: rgb(9, 105, 218);
+      text-decoration: none;
+      border-bottom: 1px solid rgb(9, 105, 218);
+      font-weight: 500;
+      width: fit-content; 
+    "
+    href="https://dashboard.url"
+  >See analysis details on SonarQube</a></div></div>"
 `;

--- a/commonv5/ts/sonarqube/types.ts
+++ b/commonv5/ts/sonarqube/types.ts
@@ -39,3 +39,23 @@ export type MetricsResponse = {
   ps: number;
   total: number;
 };
+
+export interface PeriodMeasure {
+  bestValue?: boolean;
+  index: number;
+  value: string;
+}
+
+export interface Measure {
+  metric: string;
+  bestValue?: boolean;
+  period?: PeriodMeasure;
+  value?: string;
+}
+
+export interface MeasureResponse {
+  component: {
+    measures: Measure[];
+  };
+  [key: string]: unknown;
+}


### PR DESCRIPTION
This PR tries and fetch measures in the list `[new_violations, pull_request_fixed_issues, new_accepted_issues, new_security_hotspots, new_coverage, new_duplicated_lines_density]` respecting this logic:
- Doesn't try to show `pull_request_fixed_issues` when not on pull requests
- Doesn't show coverage or duplication data if there's none to show
- Doesn't try to fetch measures if there are not listed in available metrics (`/api/metrics/search`)
- If the metric exists but could not get the measure (possible, see next paragraph), tries to get the measure value from the QG condition
- Gracefully degrades the UI when some measures are not available (see examples)

Known limitation: Measures will only be able to be fetched when a user token is used for the analysis. Project analysis and Global analysis tokens don't have the `Browser project` permission necessary to get the project measures.

This PR also includes a fix after SSF-194 which was double-stringifying scanner params in tl variables

Examples from validation
- All measures available, on pull request
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/e342fdb5-e6b8-4ad9-a074-b7c428f21834)
- No coverage or duplication data, on branch
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/8cbfaf80-8692-4a74-ae54-bcc2ca9fbf43)
- Failing condition
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/9dba4b16-5af0-443b-8778-6625d339d165)
- SQ <= 10.3, no coverage and dup data
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/164e0211-392d-4f6b-b5bf-88ae4a84aca7)
- SQ LTS
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/cffea5fe-786a-4f28-84fa-580f5152f921)
- SC, failed
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/aef2bebb-9c2d-4efe-8fdf-d3ffabeda1a4)
- SC, passed (they don't have `new_violations` metric so it won't show up until they move to the new CCT)
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/d0f84850-d853-43b4-8b36-8d813e927ab0)
