### PR TITLE
VSTS-349 Add retry mechanism during polling

### DIFF
--- a/commonv5/ts/__tests__/publish-task-test.ts
+++ b/commonv5/ts/__tests__/publish-task-test.ts
@@ -220,8 +220,13 @@ it("get report string should return undefined if ceTask times out", async () => 
 
   const result = await publishTask.getReportForTask(TASK_REPORT, METRICS, SQ_ENDPOINT, 999);
 
-  expect(result).toBeUndefined();
-  expect(Task.waitForTaskCompletion).toHaveBeenCalledWith(SQ_ENDPOINT, TASK_REPORT.ceTaskId, 999);
+  expect(result).toBe("");
+  expect(Task.waitForTaskCompletion).toHaveBeenCalledWith(
+    SQ_ENDPOINT,
+    TASK_REPORT.ceTaskId,
+    999,
+    1000,
+  );
   expect(tl.warning).toHaveBeenCalledWith(
     "Task '111' takes too long to complete. Stopping after 999s of polling. No quality gate will be displayed on build result.",
   );
@@ -265,7 +270,12 @@ it("get report string for single report", async () => {
 
   const result = await publishTask.getReportForTask(TASK_REPORT, METRICS, SQ_ENDPOINT, 999);
 
-  expect(Task.waitForTaskCompletion).toHaveBeenCalledWith(SQ_ENDPOINT, TASK_REPORT.ceTaskId, 999);
+  expect(Task.waitForTaskCompletion).toHaveBeenCalledWith(
+    SQ_ENDPOINT,
+    TASK_REPORT.ceTaskId,
+    999,
+    1000,
+  );
   expect(fetchProjectStatus).toHaveBeenCalledWith(SQ_ENDPOINT, "123");
 
   expect(result).toBe("dummy html");

--- a/commonv5/ts/helpers/request.ts
+++ b/commonv5/ts/helpers/request.ts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import * as semver from "semver";
 import Endpoint from "../sonarqube/Endpoint";
 
-interface RequestData {
+export interface RequestData {
   [x: string]: any;
 }
 

--- a/commonv5/ts/helpers/utils.ts
+++ b/commonv5/ts/helpers/utils.ts
@@ -3,6 +3,10 @@ import { PROP_NAMES } from "./constants";
 
 type ScannerParams = { [key: string]: string | undefined };
 
+export function waitFor(timeout: number) {
+  return new Promise((resolve) => setTimeout(resolve, timeout));
+}
+
 export function stringifyScannerParams(scannerParams: ScannerParams) {
   return JSON.stringify(
     scannerParams,

--- a/commonv5/ts/publish-task.ts
+++ b/commonv5/ts/publish-task.ts
@@ -116,7 +116,7 @@ export async function getReportForTask(
   timeoutSec: number,
 ): Promise<string> {
   try {
-    const task = await Task.waitForTaskCompletion(endpoint, taskReport.ceTaskId, timeoutSec);
+    const task = await Task.waitForTaskCompletion(endpoint, taskReport.ceTaskId, timeoutSec, 1000);
     const projectStatus = await fetchProjectStatus(endpoint, task.analysisId);
     const measures = await fetchRelevantMeasures(endpoint, task.componentKey, metrics);
     const analysis = HtmlAnalysisReport.getInstance(projectStatus, measures, {
@@ -140,6 +140,7 @@ export async function getReportForTask(
       tl.warning(
         `Task '${taskReport.ceTaskId}' takes too long to complete. Stopping after ${timeoutSec}s of polling. No quality gate will be displayed on build result.`,
       );
+      return "";
     } else {
       throw e;
     }

--- a/commonv5/ts/sonarqube/__tests__/Task-test.ts
+++ b/commonv5/ts/sonarqube/__tests__/Task-test.ts
@@ -1,0 +1,66 @@
+import * as tl from "azure-pipelines-task-lib/task";
+import { fetchWithRetry } from "../../helpers/api";
+import Endpoint, { EndpointType } from "../Endpoint";
+import Task, { TimeOutReachedError } from "../Task";
+
+const MOCKED_ENDPOINT = new Endpoint(EndpointType.SonarQube, { url: "https://endpoint.url" });
+
+jest.mock("../../helpers/request", () => ({
+  ...jest.requireActual("../../helpers/request"),
+  get: jest.fn(),
+}));
+
+jest.mock("../../helpers/api", () => ({
+  ...jest.requireActual("../../helpers/api"),
+  fetchWithRetry: jest.fn(),
+}));
+
+it("waits for task with success", async () => {
+  for (let i = 0; i < 4; ++i) {
+    jest.mocked(fetchWithRetry).mockResolvedValueOnce({ task: { status: "IN_PROGRESS" } });
+  }
+  jest.mocked(fetchWithRetry).mockResolvedValueOnce({ task: { status: "SUCCESS" } });
+  const task = await Task.waitForTaskCompletion(MOCKED_ENDPOINT, "taskId", 5, 1);
+  expect(task).toEqual({ task: { status: "SUCCESS" } });
+});
+
+it("waits for failing task", async () => {
+  for (let i = 0; i < 4; ++i) {
+    jest.mocked(fetchWithRetry).mockResolvedValueOnce({ task: { status: "IN_PROGRESS" } });
+  }
+  jest.mocked(fetchWithRetry).mockResolvedValueOnce({ task: { status: "CANCELED" } });
+
+  expect.assertions(1);
+  try {
+    await Task.waitForTaskCompletion(MOCKED_ENDPOINT, "taskId", 5, 1);
+  } catch (error) {
+    expect(error.message).toMatch("Task failed with status CANCELED");
+  }
+});
+
+it("should fail if polling fails", async () => {
+  jest.mocked(fetchWithRetry).mockRejectedValue(new Error("Polling failed"));
+
+  expect.assertions(1);
+  try {
+    await Task.waitForTaskCompletion(MOCKED_ENDPOINT, "taskId", 5, 1);
+  } catch (error) {
+    expect(error.message).toMatch("[SQ] Could not fetch task for ID 'taskId'");
+  }
+});
+
+it("timeout if polling takes too long", async () => {
+  jest.spyOn(tl, "debug");
+  jest.mocked(fetchWithRetry).mockResolvedValue({ task: { status: "IN_PROGRESS" } });
+
+  expect.assertions(3);
+  try {
+    await Task.waitForTaskCompletion(MOCKED_ENDPOINT, "taskId", 5, 1);
+  } catch (error) {
+    expect(error).toBeInstanceOf(TimeOutReachedError);
+    expect(tl.debug).toHaveBeenCalledWith(
+      "[SQ] Reached timeout while waiting for task to complete",
+    );
+    expect(fetchWithRetry).toHaveBeenCalledTimes(5);
+  }
+});


### PR DESCRIPTION
Here is the output in the terminal when the request fails (once):

```text
2024-01-16T12:57:37.7455381Z ##[debug][SQ] API GET: '/api/ce/task' with full URL "https://xxx.eu.ngrok.io/api/ce/task?id=AY0SWUK2VqVwuP_SOuqo" and query "{"id":"AY0SWUK2VqVwuP_SOuqo"}"
2024-01-16T12:57:37.8555253Z ##[debug][SQ] Task status:IN_PROGRESS
2024-01-16T12:57:38.8580785Z ##[debug][SQ] API GET: '/api/ce/task' with full URL "https://xxx.eu.ngrok.io/api/ce/task?id=AY0SWUK2VqVwuP_SOuqo" and query "{"id":"AY0SWUK2VqVwuP_SOuqo"}"
2024-01-16T12:57:38.9892444Z ##[debug][SQ] Task status:IN_PROGRESS
2024-01-16T12:57:39.9909318Z ##[debug][SQ] API GET: '/api/ce/task' with full URL "https://xxx.eu.ngrok.io/api/ce/task?id=AY0SWUK2VqVwuP_SOuqo" and query "{"id":"AY0SWUK2VqVwuP_SOuqo"}"
2024-01-16T12:57:40.1174809Z ##[debug][SQ] Task status:IN_PROGRESS
2024-01-16T12:57:41.1179568Z ##[debug][SQ] API GET: '/api/ce/task' with full URL "https://xxx.eu.ngrok.io/api/ce/task?id=AY0SWUK2VqVwuP_SOuqo" and query "{"id":"AY0SWUK2VqVwuP_SOuqo"}"
2024-01-16T12:57:41.2377917Z ##[debug][SQ] API GET '/api/ce/task' failed, error is invalid json response body at https://xxx.eu.ngrok.io/api/ce/task?id=AY0SWUK2VqVwuP_SOuqo reason: Unexpected token < in JSON at position 0
2024-01-16T12:57:41.2379089Z ##[debug][SQ] API GET '/api/ce/task' failed (attempt 1/3)
2024-01-16T12:57:43.2407634Z ##[debug][SQ] API GET: '/api/ce/task' with full URL "https://xxx.eu.ngrok.io/api/ce/task?id=AY0SWUK2VqVwuP_SOuqo" and query "{"id":"AY0SWUK2VqVwuP_SOuqo"}"
2024-01-16T12:57:43.3708339Z ##[debug][SQ] Task status:SUCCESS
2024-01-16T12:57:43.3710283Z ##[debug][SQ] Task complete:  [..]
```

If it fails consistently:

```text
##[debug][SQ] API GET: '/api/ce/task' with full URL "[https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx"](https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx%22) and query "{"id":"AY0SXqBEVqVwuP_SOuqx"}"
##[debug][SQ] Task status:IN_PROGRESS
##[debug][SQ] API GET: '/api/ce/task' with full URL "[https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx"](https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx%22) and query "{"id":"AY0SXqBEVqVwuP_SOuqx"}"
##[debug][SQ] API GET '/api/ce/task' failed, error is invalid json response body at https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx reason: Unexpected token < in JSON at position 0
##[debug][SQ] API GET '/api/ce/task' failed (attempt 1/3)
##[debug][SQ] API GET: '/api/ce/task' with full URL "[https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx"](https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx%22) and query "{"id":"AY0SXqBEVqVwuP_SOuqx"}"
##[debug][SQ] API GET '/api/ce/task' failed, error is invalid json response body at https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx reason: Unexpected token < in JSON at position 0
##[debug][SQ] API GET '/api/ce/task' failed (attempt 2/3)
##[debug][SQ] API GET: '/api/ce/task' with full URL "[https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx"](https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx%22) and query "{"id":"AY0SXqBEVqVwuP_SOuqx"}"
##[debug][SQ] API GET '/api/ce/task' failed, error is invalid json response body at https://xxx.eu.ngrok.io/api/ce/task?id=AY0SXqBEVqVwuP_SOuqx reason: Unexpected token < in JSON at position 0
##[debug][SQ] API GET '/api/ce/task' failed (attempt 3/3)
##[error][SQ] API GET '/api/ce/task' failed, max attempts reached
##[debug]Processed: ##vso[task.issue type=error;][SQ] API GET '/api/ce/task' failed, max attempts reached
##[debug][SQ] Publish task error: [SQ] Could not fetch task for ID 'AY0SXqBEVqVwuP_SOuqx'
##[debug]task result: Failed
##[error][SQ] Could not fetch task for ID 'AY0SXqBEVqVwuP_SOuqx'
```