### PR TITLE
VSTS-350 Treat pull requests correctly on SonarQube Next instance

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -702,7 +702,9 @@ gulp.task("sonarqube-analysis:sonarqube", (done) => {
   } else if (process.env.CIRRUS_PR !== "false") {
     runSonnarQubeScanner(done, {
       "sonar.analysis.prNumber": process.env.CIRRUS_PR,
-      "sonar.branch.name": process.env.CIRRUS_BRANCH,
+      "sonar.pullrequest.key": process.env.CIRRUS_PR,
+      "sonar.pullrequest.branch": process.env.CIRRUS_BRANCH,
+      "sonar.pullrequest.base": process.env.CIRRUS_BASE,
       "sonar.analysis.sha1": process.env.CIRRUS_BASE_SHA,
       "sonar.projectVersion": projectVersion,
     });
@@ -723,7 +725,9 @@ gulp.task("sonarqube-analysis:sonarcloud", (done) => {
   } else if (process.env.CIRRUS_PR !== "false") {
     runSonnarQubeScannerForSonarCloud(done, {
       "sonar.analysis.prNumber": process.env.CIRRUS_PR,
-      "sonar.branch.name": process.env.CIRRUS_BRANCH,
+      "sonar.pullrequest.key": process.env.CIRRUS_PR,
+      "sonar.pullrequest.branch": process.env.CIRRUS_BRANCH,
+      "sonar.pullrequest.base": process.env.CIRRUS_BASE,
       "sonar.analysis.sha1": process.env.CIRRUS_BASE_SHA,
       "sonar.projectVersion": projectVersion,
     });


### PR DESCRIPTION
We were never using pull request analysis correctly on our Next SonarQube instance. We were actually using branch analysis instead of pull request analyses. A side effect is that we never had pull request decoration in our PRs.

This PR fixes the way we run SQ analysis in our gulp task, so we'll have PR decoration now