### PR TITLE
VSTS-350 Fix Next SQ branch analysis and CIRRUS_PR usage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,6 +52,7 @@ build_task:
     - npm install
     - npm run install-dep-full
   script:
+    - git fetch
     - source cirrus-env BUILD
     - npm run validate-ci
     - npm run sonarqube
@@ -78,7 +79,7 @@ promote_task:
 mend_scan_task:
   depends_on:
     - build
-  only_if:  $CIRRUS_BRANCH == "master"
+  only_if: $CIRRUS_BRANCH == "master"
   timeout_in: 30m
   eks_container:
     <<: *CONTAINER_TEMPLATE

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -519,11 +519,11 @@ gulp.task("build:test", gulp.series("clean", "copy", "test", "tfx:test"));
  * =========================
  */
 gulp.task("deploy:vsix:sonarqube", () => {
-  if (process.env.CIRRUS_BRANCH !== "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH !== "master" && !process.env.CIRRUS_PR) {
     gutil.log("Not on master nor PR, skip deploy:vsix");
     return gutil.noop;
   }
-  if (process.env.CIRRUS_PR === "true" && process.env.DEPLOY_PULL_REQUEST === "false") {
+  if (process.env.CIRRUS_PR && process.env.DEPLOY_PULL_REQUEST === "false") {
     gutil.log("On PR, but artifacts should not be deployed, skip deploy:vsix");
     return gutil.noop;
   }
@@ -575,11 +575,11 @@ gulp.task("deploy:vsix:sonarqube", () => {
 });
 
 gulp.task("deploy:vsix:sonarcloud", () => {
-  if (process.env.CIRRUS_BRANCH !== "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH !== "master" && !process.env.CIRRUS_PR) {
     gutil.log("Not on master nor PR, skip deploy:vsix");
     return gutil.noop;
   }
-  if (process.env.CIRRUS_PR === "true" && process.env.DEPLOY_PULL_REQUEST === "false") {
+  if (process.env.CIRRUS_PR && process.env.DEPLOY_PULL_REQUEST === "false") {
     gutil.log("On PR, but artifacts should not be deployed, skip deploy:vsix");
     return gutil.noop;
   }
@@ -634,11 +634,11 @@ gulp.task("deploy:vsix:sonarcloud", () => {
 });
 
 gulp.task("deploy:buildinfo", () => {
-  if (process.env.CIRRUS_BRANCH !== "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH !== "master" && !process.env.CIRRUS_PR) {
     gutil.log("Not on master nor PR, skip deploy:buildinfo");
     return gutil.noop;
   }
-  if (process.env.CIRRUS_PR === "true" && process.env.DEPLOY_PULL_REQUEST === "false") {
+  if (process.env.CIRRUS_PR && process.env.DEPLOY_PULL_REQUEST === "false") {
     gutil.log("On PR, but artifacts should not be deployed, skip deploy:buildinfo");
     return gutil.noop;
   }
@@ -694,12 +694,12 @@ gulp.task("sonarqube-analysis:sonarqube", (done) => {
   const extensionPath = path.join(paths.extensions.root, "sonarqube");
   const vssExtension = fs.readJsonSync(path.join(extensionPath, "vss-extension.json"));
   const projectVersion = vssExtension.version;
-  if (process.env.CIRRUS_BRANCH === "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH === "master" && !process.env.CIRRUS_PR) {
     runSonnarQubeScanner(done, {
       "sonar.analysis.sha1": process.env.CIRRUS_CHANGE_IN_REPO,
       "sonar.projectVersion": projectVersion,
     });
-  } else if (process.env.CIRRUS_PR !== "false") {
+  } else if (process.env.CIRRUS_PR) {
     runSonnarQubeScanner(done, {
       "sonar.analysis.prNumber": process.env.CIRRUS_PR,
       "sonar.pullrequest.key": process.env.CIRRUS_PR,
@@ -717,12 +717,12 @@ gulp.task("sonarqube-analysis:sonarcloud", (done) => {
   const extensionPath = path.join(paths.extensions.root, "sonarcloud");
   const vssExtension = fs.readJsonSync(path.join(extensionPath, "vss-extension.json"));
   const projectVersion = vssExtension.version;
-  if (process.env.CIRRUS_BRANCH === "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH === "master" && !process.env.CIRRUS_PR) {
     runSonnarQubeScannerForSonarCloud(done, {
       "sonar.analysis.sha1": process.env.CIRRUS_CHANGE_IN_REPO,
       "sonar.projectVersion": projectVersion,
     });
-  } else if (process.env.CIRRUS_PR !== "false") {
+  } else if (process.env.CIRRUS_PR) {
     runSonnarQubeScannerForSonarCloud(done, {
       "sonar.analysis.prNumber": process.env.CIRRUS_PR,
       "sonar.pullrequest.key": process.env.CIRRUS_PR,
@@ -770,7 +770,7 @@ gulp.task("promote", (cb) => {
 });
 
 gulp.task("burgr:sonarcloud", () => {
-  if (process.env.CIRRUS_BRANCH !== "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH !== "master" && !process.env.CIRRUS_PR) {
     gutil.log("Not on master nor PR, skip burgr");
     return gutil.noop;
   }
@@ -807,7 +807,7 @@ gulp.task("burgr:sonarcloud", () => {
 });
 
 gulp.task("burgr:sonarqube", () => {
-  if (process.env.CIRRUS_BRANCH !== "master" && process.env.CIRRUS_PR === "false") {
+  if (process.env.CIRRUS_BRANCH !== "master" && !process.env.CIRRUS_PR) {
     gutil.log("Not on master nor PR, skip burgr");
     return gutil.noop;
   }


### PR DESCRIPTION
[this commit](https://github.com/SonarSource/sonar-scanner-vsts/commit/f7102231e6a0b251fa7bd8f984ed8cb389050cd2) added PR decoration but also introduced a regression for branch builds (1), and it wasn't properly analyzing PRs because of an old bug in the gulp file (2).

(1) This PR fixes the usage of [`CIRRUS_PR`](https://cirrus-ci.org/guide/writing-tasks/#environment-variables) which was never correct. The current code assumes `CIRRUS_PR` can take values `false` or `true` but in fact, these are the actual values:
- On master branch, it's unset
- In PR: ![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/fb4c934e-a666-4578-95e2-3ef27eea66bb)

(2) In PR analyses, no change was detected because the CI environment did not have the `master` branch to compare the changes between the PR branch and the target branch. Adding `git fetch` solves this