### PR TITLE
SonarQube analyze jdkversion default value bump to Java 17

### DIFF
--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 19,
+    "Minor": 20,
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
@@ -20,14 +20,14 @@
       "name": "jdkversion",
       "type": "pickList",
       "label": "JDK version source for analysis",
-      "defaultValue": "JAVA_HOME_11_X64",
+      "defaultValue": "JAVA_HOME_17_X64",
       "required": true,
       "options": {
         "JAVA_HOME": "Use JAVA_HOME",
         "JAVA_HOME_11_X64": "Use built-in JAVA_HOME_11_X64 (hosted agent)",
         "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)"
       },
-      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_11_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
+      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_17_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
     }
   ],
   "execution": {

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
Following #285 this updates the default value to Java17 on SonarQube extension.

---
Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-vsts/blob/master/docs/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](https://jira.sonarsource.com/browse/VSTS) ticket available, please make your commits and pull request start with the ticket ID (VSTS-XXXX)
