### PR TITLE
VSTS-355 Ignore specified JDK 11 if server does not support it

### DIFF
--- a/commonv5/ts/__tests__/analyze-task-test.ts
+++ b/commonv5/ts/__tests__/analyze-task-test.ts
@@ -1,13 +1,13 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import analyzeTask from "../../ts/analyze-task";
+import { JdkVersionSource, TASK_MISSING_VARIABLE_ERROR_HINT } from "../helpers/constants";
 import Scanner, { ScannerCLI, ScannerMode } from "../sonarqube/Scanner";
-import { TASK_MISSING_VARIABLE_ERROR_HINT } from "../helpers/constants";
 
 it("should not have SONARQUBE_SCANNER_MODE property filled", async () => {
   jest.spyOn(tl, "getVariable").mockImplementation(() => undefined);
   jest.spyOn(tl, "setResult").mockImplementation(() => null);
 
-  await analyzeTask(__dirname, "JAVA_HOME");
+  await analyzeTask(__dirname, JdkVersionSource.JavaHome);
 
   expect(tl.setResult).toHaveBeenCalledWith(
     tl.TaskResult.Failed,
@@ -16,6 +16,9 @@ it("should not have SONARQUBE_SCANNER_MODE property filled", async () => {
 });
 
 it("should run scanner", async () => {
+  //SONARQUBE_SERVER_VERSION
+  jest.spyOn(tl, "getVariable").mockReturnValueOnce("9.9.0.213");
+
   //SONARQUBE_SCANNER_MODE
   jest.spyOn(tl, "getVariable").mockReturnValueOnce("CLI");
   jest.spyOn(tl, "getVariable").mockReturnValueOnce("CLI");
@@ -49,7 +52,7 @@ it("should run scanner", async () => {
 
   jest.spyOn(scanner, "runAnalysis").mockImplementation(() => null);
 
-  await analyzeTask(__dirname, "JAVA_HOME");
+  await analyzeTask(__dirname, JdkVersionSource.JavaHome);
 
   expect(Scanner.getAnalyzeScanner).toHaveBeenCalledWith(__dirname, ScannerMode.CLI);
 

--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -1,3 +1,5 @@
+import * as semver from "semver";
+
 export const PROP_NAMES = {
   HOST_URL: "sonar.host.url",
   TOKEN: "sonar.token",
@@ -10,6 +12,12 @@ export const PROP_NAMES = {
   PROJECTSOURCES: "sonar.sources",
   PROJECTSETTINGS: "project.settings",
 };
+
+export enum JdkVersionSource {
+  JavaHome = "JAVA_HOME",
+  JavaHome11 = "JAVA_HOME_11_X64",
+  JavaHome17 = "JAVA_HOME_17_X64",
+}
 
 export enum AzureProvider {
   TfsGit = "TfsGit",
@@ -55,3 +63,8 @@ export const SQ_BRANCH_MEASURES = [
   "new_coverage",
   "new_duplicated_lines_density",
 ];
+
+/**
+ * First SQ version that drops support for Java 11
+ */
+export const SQ_VERSION_DROPPING_JAVA_11 = semver.coerce("10.4");

--- a/commonv5/ts/helpers/java-version-resolver.ts
+++ b/commonv5/ts/helpers/java-version-resolver.ts
@@ -1,44 +1,69 @@
 import * as tl from "azure-pipelines-task-lib/task";
-import { TaskVariables } from "./constants";
+import * as semver from "semver";
+import { EndpointType } from "../sonarqube/Endpoint";
+import { JdkVersionSource, SQ_VERSION_DROPPING_JAVA_11, TaskVariables } from "./constants";
 
 export default class JavaVersionResolver {
+  /**
+   * The value of JAVA_HOME env. variable before this task started.
+   */
   private static javaHomeOriginalPath: string;
-  private static isJavaNewVersionSet: boolean = false;
 
-  public static lookupVariable(jdkversionSource: string): string | undefined {
-    tl.debug(`Trying to resolve ${jdkversionSource} from environment variables...`);
-    const javaPath = tl.getVariable(jdkversionSource);
-    if (javaPath) {
+  /**
+   * Whether this task changed the JAVA_HOME variable.
+   */
+  private static isJavaVersionChanged = false;
+
+  public static setJavaVersion(
+    jdkVersion: JdkVersionSource,
+    endpointType: EndpointType,
+    serverVersion?: string,
+  ) {
+    if (jdkVersion === JdkVersionSource.JavaHome) {
       tl.debug(
-        `${jdkversionSource} was found with value ${javaPath}, will switch to it for Sonar scanner...`,
+        `${JdkVersionSource.JavaHome} was specified in the Run Code Analysis task configuration, nothing to do.`,
       );
-      return javaPath;
-    } else {
-      tl.debug(`No value found for ${jdkversionSource}.`);
-      return undefined;
+      return;
+    }
+
+    /**
+     * Ignore Java 11 setting it the SQ server doesn't support it @see VSTS-355
+     */
+    const ignoreJava11 =
+      serverVersion &&
+      semver.gte(semver.coerce(serverVersion), SQ_VERSION_DROPPING_JAVA_11) &&
+      endpointType === EndpointType.SonarQube;
+    if (ignoreJava11 && jdkVersion === JdkVersionSource.JavaHome11) {
+      tl.warning(
+        `This task was configured to use Java 11, but the ${endpointType} server v${serverVersion} does not support it.` +
+          ` Ignoring the configuration and using ${JdkVersionSource.JavaHome} instead.` +
+          ` Specify jdkversion in your task definition to use Java 17 to remove this warning.`,
+      );
+      return;
+    }
+
+    // Try and read the java path
+    const newJavaPath = tl.getVariable(jdkVersion);
+
+    if (newJavaPath) {
+      tl.debug(
+        `${jdkVersion} was found with value ${newJavaPath}, will switch to it for Sonar scanner...`,
+      );
+      this.javaHomeOriginalPath = tl.getVariable(TaskVariables.JavaHome);
+      // Replace the JAVA_HOME variable with the new path
+      tl.setVariable(TaskVariables.JavaHome, newJavaPath);
+      this.isJavaVersionChanged = true;
     }
   }
 
-  public static setJavaVersion(jdkversionSource: string) {
-    let newJavaPath = undefined;
-    if (jdkversionSource !== "JAVA_HOME") {
-      newJavaPath = this.lookupVariable(jdkversionSource);
-      if (newJavaPath) {
-        this.javaHomeOriginalPath = tl.getVariable(TaskVariables.JavaHome);
-        tl.setVariable(TaskVariables.JavaHome, newJavaPath);
-        this.isJavaNewVersionSet = true;
-      }
-    } else {
-      tl.debug(
-        `JAVA_HOME was specified in the Run Code Analysis task configuration, nothing to do.`,
-      );
-    }
-  }
-
+  /**
+   * Clean up the JAVA_HOME variable if it was changed by this task.
+   */
   public static revertJavaHomeToOriginal() {
-    if (this.isJavaNewVersionSet) {
-      tl.debug("Reverting JAVA_HOME to its initial path.");
+    if (this.isJavaVersionChanged) {
+      tl.debug(`Reverting ${TaskVariables.JavaHome} to its initial path.`);
       tl.setVariable(TaskVariables.JavaHome, this.javaHomeOriginalPath);
+      this.isJavaVersionChanged = false;
     }
   }
 }

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 5,
     "Minor": 19,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/prepare/v5/task.json
+++ b/extensions/sonarqube/tasks/prepare/v5/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 5,
     "Minor": 19,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/publish/v5/task.json
+++ b/extensions/sonarqube/tasks/publish/v5/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 5,
     "Minor": 6,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "inputs": [

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.19.1",
+  "version": "5.19.2",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
We can not just switch to Java 17 by default, because we would break users that do not have Java 17 installed in their agents.

Instead, we:
- Ignore the specified Java 11 if we know the server does not support it (SonarQube >= 10.4). In that case, switch to using the default JAVA_HOME.
- Add a warning message to the task when we ignore it and tell users to update the task to specify jdkversion
