### PR TITLE
VSTS-360 Add support to select JDK21 on hosted agents

### DIFF
--- a/commonv5/ts/helpers/__tests__/java-version-resolver-test.ts
+++ b/commonv5/ts/helpers/__tests__/java-version-resolver-test.ts
@@ -7,6 +7,7 @@ const MOCKED_JAVA_VARIABLES = {
   [JdkVersionSource.JavaHome]: "/opt/bin/java/bin",
   [JdkVersionSource.JavaHome11]: "/opt/bin/java11/bin",
   [JdkVersionSource.JavaHome17]: "/opt/bin/java17/bin",
+  [JdkVersionSource.JavaHome21]: "/opt/bin/java21/bin",
 };
 
 beforeEach(() => {
@@ -36,8 +37,10 @@ describe("JavaVersionResolver", () => {
     [EndpointType.SonarQube, "9.9.0", JdkVersionSource.JavaHome11, "/opt/bin/java11/bin"],
     [EndpointType.SonarQube, "9.9.0", JdkVersionSource.JavaHome17, "/opt/bin/java17/bin"],
     [EndpointType.SonarQube, "10.4", JdkVersionSource.JavaHome17, "/opt/bin/java17/bin"],
+    [EndpointType.SonarQube, "10.4", JdkVersionSource.JavaHome21, "/opt/bin/java21/bin"],
     [EndpointType.SonarCloud, "8.0.0", JdkVersionSource.JavaHome11, "/opt/bin/java11/bin"],
     [EndpointType.SonarCloud, "8.0.0", JdkVersionSource.JavaHome17, "/opt/bin/java17/bin"],
+    [EndpointType.SonarCloud, "8.0.0", JdkVersionSource.JavaHome21, "/opt/bin/java21/bin"],
   ])(
     "should use specified java version if specified and it exists (%s, %s, %s, %s)",
     (endpointType, serverVersion, jdkVersion, path) => {

--- a/commonv5/ts/helpers/constants.ts
+++ b/commonv5/ts/helpers/constants.ts
@@ -17,6 +17,7 @@ export enum JdkVersionSource {
   JavaHome = "JAVA_HOME",
   JavaHome11 = "JAVA_HOME_11_X64",
   JavaHome17 = "JAVA_HOME_17_X64",
+  JavaHome21 = "JAVA_HOME_21_X64",
 }
 
 export enum AzureProvider {

--- a/extensions/sonarcloud/tasks/analyze/v1/task.json
+++ b/extensions/sonarcloud/tasks/analyze/v1/task.json
@@ -9,7 +9,7 @@
   "author": "sonarsource",
   "version": {
     "Major": 1,
-    "Minor": 44,
+    "Minor": 45,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarcloud/tasks/analyze/v1/task.json
+++ b/extensions/sonarcloud/tasks/analyze/v1/task.json
@@ -5,9 +5,7 @@
   "description": "Run scanner and upload the results to the SonarCloud server.",
   "helpMarkDown": "This task is not needed for Maven and Gradle projects since the scanner should be run as part of the build.\n\n[More Information](https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarcloud-extension-for-azure-devops/)",
   "category": "Build",
-  "visibility": [
-    "Build"
-  ],
+  "visibility": ["Build"],
   "author": "sonarsource",
   "version": {
     "Major": 1,
@@ -15,9 +13,7 @@
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
-  "demands": [
-    "java"
-  ],
+  "demands": ["java"],
   "inputs": [
     {
       "name": "jdkversion",
@@ -26,9 +22,10 @@
       "defaultValue": "JAVA_HOME_17_X64",
       "required": true,
       "options": {
-          "JAVA_HOME": "Use JAVA_HOME",
-          "JAVA_HOME_11_X64": "Use built-in JAVA_HOME_11_X64 (hosted agent)",
-          "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)"
+        "JAVA_HOME": "Use JAVA_HOME",
+        "JAVA_HOME_11_X64": "Use built-in JAVA_HOME_11_X64 (hosted agent)",
+        "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)",
+        "JAVA_HOME_21_X64": "Use built-in JAVA_HOME_21_X64 (hosted agent)"
       },
       "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_17_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
     }

--- a/extensions/sonarcloud/vss-extension.json
+++ b/extensions/sonarcloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarcloud",
   "name": "SonarCloud",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"
@@ -15,19 +15,11 @@
   ],
   "description": "Detect bugs, vulnerabilities and code smells across project branches and pull requests.",
   "public": true,
-  "categories": [
-    "Azure Pipelines"
-  ],
+  "categories": ["Azure Pipelines"],
   "icons": {
     "default": "extension-icon.png"
   },
-  "tags": [
-    "build",
-    "ci",
-    "continuous integration",
-    "code quality",
-    "static code analysis"
-  ],
+  "tags": ["build", "ci", "continuous integration", "code quality", "static code analysis"],
   "content": {
     "details": {
       "path": "overview.md"
@@ -80,18 +72,12 @@
       "path": "templates"
     }
   ],
-  "scopes": [
-    "vso.build",
-    "vso.code",
-    "vso.test"
-  ],
+  "scopes": ["vso.build", "vso.code", "vso.test"],
   "contributions": [
     {
       "id": "14d9cde6-c1da-4d55-aa01-2965cd301255",
       "type": "ms.vss-distributed-task.task",
-      "targets": [
-        "ms.vss-distributed-task.tasks"
-      ],
+      "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
         "name": "tasks/prepare"
       }
@@ -99,9 +85,7 @@
     {
       "id": "ce096e50-6155-4de8-8800-4221aaeed4a1",
       "type": "ms.vss-distributed-task.task",
-      "targets": [
-        "ms.vss-distributed-task.tasks"
-      ],
+      "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
         "name": "tasks/analyze"
       }
@@ -109,9 +93,7 @@
     {
       "id": "38b27399-a642-40af-bb7d-9971f69712e8",
       "type": "ms.vss-distributed-task.task",
-      "targets": [
-        "ms.vss-distributed-task.tasks"
-      ],
+      "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
         "name": "tasks/publish"
       }
@@ -119,9 +101,7 @@
     {
       "id": "6350bfb8-c310-4cdd-af68-722f33cf440a",
       "type": "ms.vss-distributed-task.task",
-      "targets": [
-        "ms.vss-distributed-task.tasks"
-      ],
+      "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
         "name": "tasks/qgstatus"
       }
@@ -129,10 +109,7 @@
     {
       "id": "3c598f25-01c1-4c09-97c6-926476882688",
       "type": "ms.vss-dashboards-web.widget",
-      "targets": [
-        "ms.vss-dashboards-web.widget-catalog",
-        ".e56c6ff0-c6f9-43d0-bdef-b3f1aa0dc6dd"
-      ],
+      "targets": ["ms.vss-dashboards-web.widget-catalog", ".e56c6ff0-c6f9-43d0-bdef-b3f1aa0dc6dd"],
       "properties": {
         "name": "Code Quality",
         "description": "Shows the current quality status of your project based on SonarCloud.",
@@ -145,17 +122,13 @@
             "columnSpan": 1
           }
         ],
-        "supportedScopes": [
-          "project_team"
-        ]
+        "supportedScopes": ["project_team"]
       }
     },
     {
       "id": "e56c6ff0-c6f9-43d0-bdef-b3f1aa0dc6dd",
       "type": "ms.vss-dashboards-web.widget-configuration",
-      "targets": [
-        "ms.vss-dashboards-web.widget-configuration"
-      ],
+      "targets": ["ms.vss-dashboards-web.widget-configuration"],
       "properties": {
         "name": "Code Quality Configuration",
         "description": "Configures Code Quality Widget",
@@ -166,9 +139,7 @@
       "id": "343c5f6a-e4d5-4480-a764-506e1daa05df",
       "description": "Service endpoint type for SonarCloud Connections",
       "type": "ms.vss-endpoint.service-endpoint-type",
-      "targets": [
-        "ms.vss-endpoint.endpoint-types"
-      ],
+      "targets": ["ms.vss-endpoint.endpoint-types"],
       "properties": {
         "name": "sonarcloud",
         "displayName": "SonarCloud",
@@ -215,9 +186,7 @@
     {
       "id": "7ae27005-05c8-46d3-a5f2-06b3b15d608b",
       "type": "ms.vss-build.template",
-      "targets": [
-        "ms.vss-build.templates"
-      ],
+      "targets": ["ms.vss-build.templates"],
       "properties": {
         "name": "templates/maven"
       }
@@ -225,9 +194,7 @@
     {
       "id": "b17d1503-2143-4e01-aada-5f8e29759a32",
       "type": "ms.vss-build.template",
-      "targets": [
-        "ms.vss-build.templates"
-      ],
+      "targets": ["ms.vss-build.templates"],
       "properties": {
         "name": "templates/gradle"
       }
@@ -235,9 +202,7 @@
     {
       "id": "5f882e5A-b102-4fe4-b0b2-de4c812d1e18",
       "type": "ms.vss-build.template",
-      "targets": [
-        "ms.vss-build.templates"
-      ],
+      "targets": ["ms.vss-build.templates"],
       "properties": {
         "name": "templates/netcore"
       }
@@ -245,9 +210,7 @@
     {
       "id": "05fc4e32-1887-480d-93bf-337f6072348e",
       "type": "ms.vss-build.template",
-      "targets": [
-        "ms.vss-build.templates"
-      ],
+      "targets": ["ms.vss-build.templates"],
       "properties": {
         "name": "templates/netdesktop"
       }
@@ -255,9 +218,7 @@
     {
       "id": "f2dcb989-20d1-4a5c-b138-0dd8f53bcf97",
       "type": "ms.vss-build.template",
-      "targets": [
-        "ms.vss-build.templates"
-      ],
+      "targets": ["ms.vss-build.templates"],
       "properties": {
         "name": "templates/otherfile"
       }
@@ -265,9 +226,7 @@
     {
       "id": "1d772a94-aac4-4395-baf6-7d2d0cb17e5d",
       "type": "ms.vss-build.template",
-      "targets": [
-        "ms.vss-build.templates"
-      ],
+      "targets": ["ms.vss-build.templates"],
       "properties": {
         "name": "templates/othermanual"
       }

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -9,8 +9,8 @@
   "author": "sonarsource",
   "version": {
     "Major": 5,
-    "Minor": 19,
-    "Patch": 1
+    "Minor": 20,
+    "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
   "minimumAgentVersion": "2.144.0",

--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -25,7 +25,8 @@
       "options": {
         "JAVA_HOME": "Use JAVA_HOME",
         "JAVA_HOME_11_X64": "Use built-in JAVA_HOME_11_X64 (hosted agent)",
-        "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)"
+        "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)",
+        "JAVA_HOME_21_X64": "Use built-in JAVA_HOME_21_X64 (hosted agent)"
       },
       "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_11_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
     }

--- a/extensions/sonarqube/vss-extension.json
+++ b/extensions/sonarqube/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "sonarqube",
   "name": "SonarQube",
-  "version": "5.19.2",
+  "version": "5.20.0",
   "branding": {
     "color": "rgb(67, 157, 210)",
     "theme": "dark"


### PR DESCRIPTION
Add support to select JDK21 in analyze tasks of both the SonarCloud and SonarQube extensions. It is indeed now available in the hosted agents
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/894c9b50-2605-4354-8189-031da7140a39)

through 
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/48a9a118-228e-43f0-b5d3-8a26e88d8cbe)
![image](https://github.com/SonarSource/sonar-scanner-vsts/assets/31401273/9692000c-e809-4fb7-befa-8180412bbc7f)
