### PR TITLE
VSTS-362 Bump MSBuild scanner to 5.15.1

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,4 @@
-const msBuildVersion = "5.15.0.80890";
+const msBuildVersion = "5.15.1.88158";
 const cliVersion = "4.8.1.3023"; // Has to be the same version as the one embedded in the Scanner for MSBuild
 
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${msBuildVersion}/`;


### PR DESCRIPTION
This brings [a backported fix](https://github.com/SonarSource/sonar-scanner-msbuild/releases/tag/5.15.1.88158) to the extensions.