### PR TITLE
change defaultvalue to reflect same changes in sonarcloud

### DIFF
--- a/extensions/sonarqube/tasks/analyze/v5/task.json
+++ b/extensions/sonarqube/tasks/analyze/v5/task.json
@@ -20,7 +20,7 @@
       "name": "jdkversion",
       "type": "pickList",
       "label": "JDK version source for analysis",
-      "defaultValue": "JAVA_HOME_11_X64",
+      "defaultValue": "JAVA_HOME_17_X64",
       "required": true,
       "options": {
         "JAVA_HOME": "Use JAVA_HOME",
@@ -28,7 +28,7 @@
         "JAVA_HOME_17_X64": "Use built-in JAVA_HOME_17_X64 (hosted agent)",
         "JAVA_HOME_21_X64": "Use built-in JAVA_HOME_21_X64 (hosted agent)"
       },
-      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_11_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
+      "helpMarkDown": "Select the wanted Java version for the analysis : You can choose with either Self provided JAVA_HOME which will pick up the value of this env variable, or you can choose the built-in JAVA_HOME_XX_X64 value on hosted agent. \nDefault value is JAVA_HOME_17_X64, however if you choose either of the proposed value and they are not available, JAVA_HOME value will be picked up instead."
     }
   ],
   "execution": {


### PR DESCRIPTION
Hi there, motives for change:
* current implementation defaults to java 11, which is not enough for the latest SonarQube version. See https://community.sonarsource.com/t/azure-pipelines-scanner-suddenly-requires-a-newer-java-version/112504
