### PR TITLE
VSTS-268 Bundle and tree-shake extension task code

### DIFF
--- a/config/utils.js
+++ b/config/utils.js
@@ -193,7 +193,7 @@ exports.runSonnarQubeScanner = function (callback, options = {}) {
     "sonar.projectName": "Azure DevOps extension for SonarQube",
     "sonar.exclusions":
       "build/**, extensions/sonarcloud/**, coverage/**, node_modules/**, **/node_modules/**, **/__tests__/**," +
-      "**/temp-find-method.ts, **/package-lock.json, gulpfile.js, **/jest.config.js",
+      "**/temp-find-method.ts, **/package-lock.json, gulpfile.js, **/jest.config.js, **/esbuild.config.js",
   };
   runSonarQubeScannerImpl(callback, customOptions, options);
 };
@@ -204,7 +204,7 @@ exports.runSonnarQubeScannerForSonarCloud = function (callback, options = {}) {
     "sonar.projectName": "Azure DevOps extension for SonarCloud",
     "sonar.exclusions":
       "build/**, extensions/sonarqube/**, coverage/**, node_modules/**, **/node_modules/**, **/__tests__/**, " +
-      "**/temp-find-method.ts, **/package-lock.json, gulpfile.js, **/jest.config.js",
+      "**/temp-find-method.ts, **/package-lock.json, gulpfile.js, **/jest.config.js, **/esbuild.config.js",
   };
   runSonarQubeScannerImpl(callback, customOptions, options);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "gulp-decompress": "2.0.2",
         "gulp-download": "0.0.1",
         "gulp-exec": "5.0.0",
+        "gulp-file": "^0.4.0",
         "gulp-json-editor": "2.5.6",
         "gulp-rename": "1.2.2",
         "gulp-replace": "0.6.1",
@@ -6575,6 +6576,68 @@
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/gulp-file": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-file/-/gulp-file-0.4.0.tgz",
+      "integrity": "sha512-3NPCJpAPpbNoV2aml8T96OK3Aof4pm4PMOIa1jSQbMNSNUUXdZ5QjVgLXLStjv0gg9URcETc7kvYnzXdYXUWug==",
+      "dev": true,
+      "dependencies": {
+        "through2": "^0.4.1",
+        "vinyl": "^2.1.0"
+      }
+    },
+    "node_modules/gulp-file/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/gulp-file/node_modules/object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
+      "dev": true
+    },
+    "node_modules/gulp-file/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/gulp-file/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
+    "node_modules/gulp-file/node_modules/through2": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      }
+    },
+    "node_modules/gulp-file/node_modules/xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "~0.4.0"
+      },
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/gulp-json-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "dateformat": "3.0.3",
         "del": "3.0.0",
         "es5-ext": "0.10.64",
+        "esbuild": "^0.21.3",
         "eslint": "8.48.0",
         "eslint-plugin-import": "2.28.1",
         "eslint-plugin-promise": "6.1.1",
@@ -614,6 +615,374 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.3.tgz",
+      "integrity": "sha512-yTgnwQpFVYfvvo4SvRFB0SwrW8YjOxEoT7wfMT7Ol5v7v5LDNvSGo67aExmxOb87nQNeWPVvaGBNfQ7BXcrZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.3.tgz",
+      "integrity": "sha512-bviJOLMgurLJtF1/mAoJLxDZDL6oU5/ztMHnJQRejbJrSc9FFu0QoUoFhvi6qSKJEw9y5oGyvr9fuDtzJ30rNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.3.tgz",
+      "integrity": "sha512-c+ty9necz3zB1Y+d/N+mC6KVVkGUUOcm4ZmT5i/Fk5arOaY3i6CA3P5wo/7+XzV8cb4GrI/Zjp8NuOQ9Lfsosw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.3.tgz",
+      "integrity": "sha512-JReHfYCRK3FVX4Ra+y5EBH1b9e16TV2OxrPAvzMsGeES0X2Ndm9ImQRI4Ket757vhc5XBOuGperw63upesclRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.3.tgz",
+      "integrity": "sha512-U3fuQ0xNiAkXOmQ6w5dKpEvXQRSpHOnbw7gEfHCRXPeTKW9sBzVck6C5Yneb8LfJm0l6le4NQfkNPnWMSlTFUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.3.tgz",
+      "integrity": "sha512-3m1CEB7F07s19wmaMNI2KANLcnaqryJxO1fXHUV5j1rWn+wMxdUYoPyO2TnAbfRZdi7ADRwJClmOwgT13qlP3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.3.tgz",
+      "integrity": "sha512-fsNAAl5pU6wmKHq91cHWQT0Fz0vtyE1JauMzKotrwqIKAswwP5cpHUCxZNSTuA/JlqtScq20/5KZ+TxQdovU/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.3.tgz",
+      "integrity": "sha512-tci+UJ4zP5EGF4rp8XlZIdq1q1a/1h9XuronfxTMCNBslpCtmk97Q/5qqy1Mu4zIc0yswN/yP/BLX+NTUC1bXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.3.tgz",
+      "integrity": "sha512-f6kz2QpSuyHHg01cDawj0vkyMwuIvN62UAguQfnNVzbge2uWLhA7TCXOn83DT0ZvyJmBI943MItgTovUob36SQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.3.tgz",
+      "integrity": "sha512-vvG6R5g5ieB4eCJBQevyDMb31LMHthLpXTc2IGkFnPWS/GzIFDnaYFp558O+XybTmYrVjxnryru7QRleJvmZ6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.3.tgz",
+      "integrity": "sha512-HjCWhH7K96Na+66TacDLJmOI9R8iDWDDiqe17C7znGvvE4sW1ECt9ly0AJ3dJH62jHyVqW9xpxZEU1jKdt+29A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.3.tgz",
+      "integrity": "sha512-BGpimEccmHBZRcAhdlRIxMp7x9PyJxUtj7apL2IuoG9VxvU/l/v1z015nFs7Si7tXUwEsvjc1rOJdZCn4QTU+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.3.tgz",
+      "integrity": "sha512-5rMOWkp7FQGtAH3QJddP4w3s47iT20hwftqdm7b+loe95o8JU8ro3qZbhgMRy0VuFU0DizymF1pBKkn3YHWtsw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.3.tgz",
+      "integrity": "sha512-h0zj1ldel89V5sjPLo5H1SyMzp4VrgN1tPkN29TmjvO1/r0MuMRwJxL8QY05SmfsZRs6TF0c/IDH3u7XYYmbAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.3.tgz",
+      "integrity": "sha512-dkAKcTsTJ+CRX6bnO17qDJbLoW37npd5gSNtSzjYQr0svghLJYGYB0NF1SNcU1vDcjXLYS5pO4qOW4YbFama4A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.3.tgz",
+      "integrity": "sha512-vnD1YUkovEdnZWEuMmy2X2JmzsHQqPpZElXx6dxENcIwTu+Cu5ERax6+Ke1QsE814Zf3c6rxCfwQdCTQ7tPuXA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.3.tgz",
+      "integrity": "sha512-IOXOIm9WaK7plL2gMhsWJd+l2bfrhfilv0uPTptoRoSb2p09RghhQQp9YY6ZJhk/kqmeRt6siRdMSLLwzuT0KQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.3.tgz",
+      "integrity": "sha512-uTgCwsvQ5+vCQnqM//EfDSuomo2LhdWhFPS8VL8xKf+PKTCrcT/2kPPoWMTs22aB63MLdGMJiE3f1PHvCDmUOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.3.tgz",
+      "integrity": "sha512-vNAkR17Ub2MgEud2Wag/OE4HTSI6zlb291UYzHez/psiKarp0J8PKGDnAhMBcHFoOHMXHfExzmjMojJNbAStrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.3.tgz",
+      "integrity": "sha512-W8H9jlGiSBomkgmouaRoTXo49j4w4Kfbl6I1bIdO/vT0+0u4f20ko3ELzV3hPI6XV6JNBVX+8BC+ajHkvffIJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.3.tgz",
+      "integrity": "sha512-EjEomwyLSCg8Ag3LDILIqYCZAq/y3diJ04PnqGRgq8/4O3VNlXyMd54j/saShaN4h5o5mivOjAzmU6C3X4v0xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.3.tgz",
+      "integrity": "sha512-WGiE/GgbsEwR33++5rzjiYsKyHywE8QSZPF7Rfx9EBfK3Qn3xyR6IjyCr5Uk38Kg8fG4/2phN7sXp4NPWd3fcw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.3.tgz",
+      "integrity": "sha512-xRxC0jaJWDLYvcUvjQmHCJSfMrgmUuvsoXgDeU/wTorQ1ngDdUBuFtgY3W1Pc5sprGAvZBtWdJX7RPg/iZZUqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4441,6 +4810,44 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.3.tgz",
+      "integrity": "sha512-Kgq0/ZsAPzKrbOjCQcjoSmPoWhlcVnGAUo7jvaLHoxW1Drto0KGkR1xBNg2Cp43b9ImvxmPEJZ9xkfcnqPsfBw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.3",
+        "@esbuild/android-arm": "0.21.3",
+        "@esbuild/android-arm64": "0.21.3",
+        "@esbuild/android-x64": "0.21.3",
+        "@esbuild/darwin-arm64": "0.21.3",
+        "@esbuild/darwin-x64": "0.21.3",
+        "@esbuild/freebsd-arm64": "0.21.3",
+        "@esbuild/freebsd-x64": "0.21.3",
+        "@esbuild/linux-arm": "0.21.3",
+        "@esbuild/linux-arm64": "0.21.3",
+        "@esbuild/linux-ia32": "0.21.3",
+        "@esbuild/linux-loong64": "0.21.3",
+        "@esbuild/linux-mips64el": "0.21.3",
+        "@esbuild/linux-ppc64": "0.21.3",
+        "@esbuild/linux-riscv64": "0.21.3",
+        "@esbuild/linux-s390x": "0.21.3",
+        "@esbuild/linux-x64": "0.21.3",
+        "@esbuild/netbsd-x64": "0.21.3",
+        "@esbuild/openbsd-x64": "0.21.3",
+        "@esbuild/sunos-x64": "0.21.3",
+        "@esbuild/win32-arm64": "0.21.3",
+        "@esbuild/win32-ia32": "0.21.3",
+        "@esbuild/win32-x64": "0.21.3"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dateformat": "3.0.3",
     "del": "3.0.0",
     "es5-ext": "0.10.64",
+    "esbuild": "^0.21.3",
     "eslint": "8.48.0",
     "eslint-plugin-import": "2.28.1",
     "eslint-plugin-promise": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-decompress": "2.0.2",
     "gulp-download": "0.0.1",
     "gulp-exec": "5.0.0",
+    "gulp-file": "^0.4.0",
     "gulp-json-editor": "2.5.6",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.6.1",

--- a/src/common/latest/esbuild.config.js
+++ b/src/common/latest/esbuild.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node16",
+  minify: true,
+};

--- a/src/common/latest/esbuild.config.js
+++ b/src/common/latest/esbuild.config.js
@@ -4,4 +4,8 @@ module.exports = {
   format: "cjs",
   target: "node16",
   minify: true,
+  /**
+   * @see https://github.com/microsoft/azure-pipelines-task-lib/issues/942#issuecomment-1904939900
+   */
+  external: ["shelljs"],
 };

--- a/src/common/sonarcloud-v1/esbuild.config.js
+++ b/src/common/sonarcloud-v1/esbuild.config.js
@@ -4,4 +4,5 @@ module.exports = {
   format: "cjs",
   target: "node10",
   minify: true,
+  external: ["shelljs"],
 };

--- a/src/common/sonarcloud-v1/esbuild.config.js
+++ b/src/common/sonarcloud-v1/esbuild.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node10",
+  minify: true,
+};

--- a/src/common/sonarqube-v4/esbuild.config.js
+++ b/src/common/sonarqube-v4/esbuild.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node8",
+  minify: true,
+};

--- a/src/common/sonarqube-v4/esbuild.config.js
+++ b/src/common/sonarqube-v4/esbuild.config.js
@@ -4,4 +4,5 @@ module.exports = {
   format: "cjs",
   target: "node8",
   minify: true,
+  external: ["shelljs"],
 };

--- a/src/common/sonarqube-v5/esbuild.config.js
+++ b/src/common/sonarqube-v5/esbuild.config.js
@@ -4,4 +4,5 @@ module.exports = {
   format: "cjs",
   target: "node10",
   minify: true,
+  external: ["shelljs"],
 };

--- a/src/common/sonarqube-v5/esbuild.config.js
+++ b/src/common/sonarqube-v5/esbuild.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node10",
+  minify: true,
+};


### PR DESCRIPTION
Using esbuild to inline all dependencies (and drop `node_modules` from task folders)

We need to to add a workaround [for shelljs because we can not bundle it](https://github.com/7PH/azure-devops-extension-bundler-shelljs-poc)

## Size reduction

Size before this PR, on master branch with V1+V4+V5
```text
19M     dist/sonar-scanner-vsts-1.46.0-sonarcloud.vsix
37M     dist/sonar-scanner-vsts-5.20.0-sonarqube.vsix
```

Size after this PR
```text
3.4M    dist/sonar-scanner-vsts-1.46.0-sonarcloud.vsix
6.8M    dist/sonar-scanner-vsts-5.20.0-sonarqube.vsix
```

(After rebase with the 2 new versions, V1+V2+V4+V5+V6):
```text
5.0M    ./dist/sonar-scanner-vsts-2.0.0-sonarcloud.vsix
9.1M    ./dist/sonar-scanner-vsts-6.0.0-sonarqube.vsix
```

## Build time

On my machine, before
```text
[12:24:35] Finished 'default' after 34 s
```

After
```text
[12:20:45] Finished 'default' after 12 s
```