### PR TITLE
VSTS-376 Bump minimum agent version in SQ V6 & SC V2 tasks to ensure Node16 is available and transpile/bundle to Node16

### DIFF
--- a/src/common/latest/esbuild.config.js
+++ b/src/common/latest/esbuild.config.js
@@ -2,7 +2,7 @@ module.exports = {
   bundle: true,
   platform: "node",
   format: "cjs",
-  target: "node10",
+  target: "node16",
   minify: true,
   /**
    * @see https://github.com/microsoft/azure-pipelines-task-lib/issues/942#issuecomment-1904939900

--- a/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudAnalyze/v2/task.json
@@ -12,7 +12,7 @@
     "Minor": 0,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.218.0",
   "demands": ["java"],
   "inputs": [
     {
@@ -30,7 +30,7 @@
     }
   ],
   "execution": {
-    "Node10": {
+    "Node16": {
       "target": "SonarCloudAnalyze.js"
     }
   }

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
@@ -12,7 +12,7 @@
     "Minor": 0,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.218.0",
   "instanceNameFormat": "Prepare analysis on SonarCloud",
   "groups": [
     {
@@ -175,7 +175,7 @@
     }
   ],
   "execution": {
-    "Node10": {
+    "Node16": {
       "target": "SonarCloudPrepare.js"
     }
   }

--- a/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPublish/v2/task.json
@@ -12,7 +12,7 @@
     "Minor": 0,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.218.0",
   "inputs": [
     {
       "name": "pollingTimeoutSec",
@@ -25,7 +25,7 @@
   ],
   "dataSourceBindings": [],
   "execution": {
-    "Node10": {
+    "Node16": {
       "target": "SonarCloudPublish.js"
     }
   }

--- a/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubeAnalyze/v6/task.json
@@ -13,7 +13,7 @@
     "Patch": 0
   },
   "releaseNotes": "To be used with the new version of the `Prepare Analysis Configuration` task.",
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.218.0",
   "demands": ["java"],
   "inputs": [
     {

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
@@ -13,7 +13,7 @@
     "Patch": 0
   },
   "releaseNotes": "* __Support non MSBuild projects:__ This task can be used to configure analysis also for non MSBuild projects.",
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.218.0",
   "instanceNameFormat": "Prepare analysis on SonarQube",
   "groups": [
     {

--- a/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePublish/v6/task.json
@@ -8,11 +8,11 @@
   "visibility": ["Build"],
   "author": "sonarsource",
   "version": {
-    "Major": 5,
-    "Minor": 6,
-    "Patch": 1
+    "Major": 6,
+    "Minor": 0,
+    "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.218.0",
   "inputs": [
     {
       "name": "pollingTimeoutSec",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2017",
     "module": "commonjs",
     "lib": ["es2017", "DOM"],
     "noUnusedLocals": true,


### PR DESCRIPTION
[ticket](https://sonarsource.atlassian.net/browse/VSTS-376) with all the details