### PR TITLE
VSTS-369 Make cliVersion/msBuildVersion optional in pipeline yml definition

### DIFF
--- a/src/common/latest/config.ts
+++ b/src/common/latest/config.ts
@@ -1,6 +1,6 @@
-// Default Scanner versions are defined as `msBuildVersion` and `cliVersion` in
-// [sonarcloud](../../extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json)
-// [sonarqube](../../extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json)
+// When the user does not specify a specific version, these willl be the default versions used.
+const msBuildVersion = "6.2.0.85879";
+const cliVersion = "5.0.1.3006";
 
 // MSBUILD scanner location
 const scannersLocation = `https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/`;
@@ -20,6 +20,9 @@ function getCliScannerFilename(cliVersion: string) {
 }
 
 export const scanner = {
+  msBuildVersion,
+  cliVersion,
+
   msBuildUrlTemplate: (msBuildVersion: string, isWindows: boolean) => {
     const filename = isWindows
       ? getMsBuildClassicFilename(msBuildVersion)

--- a/src/common/latest/prepare-task.ts
+++ b/src/common/latest/prepare-task.ts
@@ -21,9 +21,9 @@ export const prepareTask: TaskJob = async (endpointType: EndpointType) => {
   const endpoint = Endpoint.getEndpoint(tl.getInput(endpointType, true), endpointType);
   const rootPath = __dirname;
 
-  const msBuildVersion: string = tl.getInput("msBuildVersion");
-  const cliVersion: string = tl.getInput("cliVersion");
-  const scannerMode: ScannerMode = ScannerMode[tl.getInput("scannerMode")];
+  const msBuildVersion = tl.getInput("msBuildVersion") ?? scannerConfig.msBuildVersion;
+  const cliVersion = tl.getInput("cliVersion") ?? scannerConfig.cliVersion;
+  const scannerMode = ScannerMode[tl.getInput("scannerMode")];
   const scanner = Scanner.getPrepareScanner(rootPath, scannerMode);
   const serverVersion = await getServerVersion(endpoint);
 

--- a/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
+++ b/src/extensions/sonarcloud/tasks/SonarCloudPrepare/v2/task.json
@@ -55,20 +55,18 @@
     {
       "name": "msBuildVersion",
       "type": "string",
-      "label": "MSBuild Version",
-      "defaultValue": "6.2.0.85879",
-      "required": true,
+      "label": "Scanner MSBuild Version",
+      "required": false,
       "visibleRule": "scannerMode = MSBuild",
-      "helpMarkDown": "Specify the version of MSBuild to use. Versions can be located [here](https://github.com/SonarSource/sonar-scanner-msbuild/tags)."
+      "helpMarkDown": "Specify the version of the MSBuild scanner to use. Versions can be located [here](https://github.com/SonarSource/sonar-scanner-msbuild/tags)."
     },
     {
       "name": "cliVersion",
       "type": "string",
-      "label": "CLI Version",
-      "defaultValue": "5.0.1.3006",
-      "required": true,
+      "label": "Scanner CLI Version",
+      "required": false,
       "visibleRule": "scannerMode = CLI",
-      "helpMarkDown": "Specify the version of CLI to use.  Versions can be located [here](https://github.com/SonarSource/sonar-scanner-cli/tags)."
+      "helpMarkDown": "Specify the version of the CLI scanner to use.  Versions can be located [here](https://github.com/SonarSource/sonar-scanner-cli/tags)."
     },
     {
       "name": "configMode",

--- a/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
+++ b/src/extensions/sonarqube/tasks/SonarQubePrepare/v6/task.json
@@ -46,20 +46,18 @@
     {
       "name": "msBuildVersion",
       "type": "string",
-      "label": "MSBuild Version",
-      "defaultValue": "6.2.0.85879",
-      "required": true,
+      "label": "Scanner MSBuild Version",
+      "required": false,
       "visibleRule": "scannerMode = MSBuild",
-      "helpMarkDown": "Specify the version of MSBuild to use. Versions can be located [here](https://github.com/SonarSource/sonar-scanner-msbuild/tags)."
+      "helpMarkDown": "Specify the version of the MSBuild scanner to use. Versions can be located [here](https://github.com/SonarSource/sonar-scanner-msbuild/tags)."
     },
     {
       "name": "cliVersion",
       "type": "string",
-      "label": "CLI Version",
-      "defaultValue": "5.0.1.3006",
-      "required": true,
+      "label": "Scanner CLI Version",
+      "required": false,
       "visibleRule": "scannerMode = CLI",
-      "helpMarkDown": "Specify the version of CLI to use.  Versions can be located [here](https://github.com/SonarSource/sonar-scanner-cli/tags)."
+      "helpMarkDown": "Specify the version of the CLI scanner to use. Versions can be located [here](https://github.com/SonarSource/sonar-scanner-cli/tags)."
     },
     {
       "name": "configMode",


### PR DESCRIPTION
To ensure users are, by default, using the recommended version of scanners that we specify in the latest version of the extension