### PR TITLE
SONARAZDO-427 Migrating cirrus-modules v2 to v3

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 
 def main(ctx):
     return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,6 @@ docker_build_container_template: &CONTAINER_TEMPLATE
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: t2.small
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
   region: eu-central-1
   namespace: default
 


### PR DESCRIPTION
That's for the email we've received (`Migrating cirrus-modules v2 to v3`)

- [ticket](https://sonarsource.atlassian.net/browse/SONAR-23500)
- [upgrade guide](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3621715969/Migrating+cirrus-modules+v2+to+v3+-+Cirrus+CI)