### PR TITLE
SONARAZDO-588 Assign new ownership to CI experience Squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToBinaries: true
-      slackChannel: ops-analysis-experience
+      slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Ownership updates:**
  - Updated `.github/CODEOWNERS` to assign repository ownership to `@sonarsource/code-quality-ci-experience-squad`.
  - Changed the `slackChannel` in `.github/workflows/release.yml` from `ops-analysis-experience` to `ops-ci-experience`.

<sub>This will update automatically on new commits.</sub>