### PR TITLE
SONARAZDO-600 Bump Gradle IT sonar plugin to 7.3.1 to fix Java 21 scanner requirement

### DIFF
--- a/its/fixtures/dummy-project-gradle/build.gradle
+++ b/its/fixtures/dummy-project-gradle/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id "org.sonarqube" version "5.1.0.4882"
+    id "org.sonarqube" version "7.3.1.8318"
 }
 
 group = 'com.example'


### PR DESCRIPTION
The Gradle integration tests began failing around July 22, 2026 with Gradle execution for task(s) build with options: --build-cache failed with exit code -1, despite no changes to the pipeline or fixtures.

Root cause is: We removed Java 17 as a supported scanner runtime around that time and now requires Java 21+. The Gradle fixture pinned org.sonarqube 5.1.0.4882 (below 6.0, so no JRE auto-provisioning) while the Gradle@3 task forces the analysis onto JDK 17, so the scanner engine now runs on an unsupported runtime and the build fails. 

The Maven ITs were unaffected because the pom pins no sonar plugin and resolves a recent auto-provisioning version.

This PR bumps the fixture to org.sonarqube 7.3.1.8318, which auto-provisions its own Java 21 runtime for the scanner engine. This keeps the Gradle 7.3 wrapper and JDK 17 build untouched, since auto-provisioning relaxes the plugin's minimum Gradle requirement to 5+. It will fixes all four Gradle  pipelines (v3/v4 x unix/windows), which share this fixture.

----
## Summary by Gitar

- **Build configuration:**
    - Upgraded `org.sonarqube` Gradle plugin version to `7.3.1.8318` in dummy project fixtures

<sub>This will update automatically on new commits.</sub>